### PR TITLE
Add help parameter to concatenate.py script

### DIFF
--- a/src/concatenate.py
+++ b/src/concatenate.py
@@ -19,7 +19,7 @@ parser.add_argument('-m', dest='minlength', metavar='', type=int,
 parser.add_argument('--keepnames', action='store_true', help='Do not rename sequences [False]')
 parser.add_argument('--nozip', action='store_true', help='Do not gzip output [False]')
 
-if len(sys.argv) == 1:
+if len(sys.argv) == 1 or sys.argv[1] in ("-h", "--help"):
     parser.print_help()
     sys.exit()
 


### PR DESCRIPTION
Hi,

I was taking some time to understand how to check the help for the `concatenate.py` script. I hope this change will make accessing the help prompt easier.

Summary of changes:
  - Add `-h/--help` flags to concatenate.py

  Previously, only running `concatenate.py` with no arguments printed the
  help command. Now, the user can call the script w/ the `-h/--help` flags.
  Additional flags can be added to L22.

Best,
V