### PR TITLE
WIP: Add Black formatter CI

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,12 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable

--- a/test/cluster.py
+++ b/test/cluster.py
@@ -126,6 +126,6 @@ class TestPairs(unittest.TestCase):
         self.assertTrue(all(len(i[1]) > 0 for i in pairs))
         self.assertTrue(sum(map(lambda i: len(i[1]), pairs)), len(nameset))
         allmembers = set()
-        for (medoid, mems) in pairs:
+        for medoid, mems in pairs:
             allmembers.update(mems)
         self.assertEqual(allmembers, nameset)

--- a/test/results.py
+++ b/test/results.py
@@ -52,6 +52,7 @@ class TestAbundanceResult(unittest.TestCase):
         )
         self.assertTrue(np.all(np.abs(abundance.matrix - abundance2.matrix) < 1e-5))
 
+
 class TestEncodingResult(unittest.TestCase):
     torch.manual_seed(0)
 
@@ -85,15 +86,16 @@ class TestEncodingResult(unittest.TestCase):
             "c417b9722e14e854fbe79cc5c797cc6653360c1e6536064205ca0c073f41eaf6",
         )
 
+
 class TestClusterResult(unittest.TestCase):
     def test_result(self):
         rng = np.random.RandomState(15)
         latent = rng.random((1000, 3)).astype(np.float32) - 0.5
         self.assertEqual(
             sha256(latent.tobytes()).digest().hex(),
-            "630a98a4b44c3754a3f423e915847f44767bb69fb13ea5901dc512428aee9811"
+            "630a98a4b44c3754a3f423e915847f44767bb69fb13ea5901dc512428aee9811",
         )
-        
+
         hash = sha256()
 
         # Use this to check that the clustering used in this test produces
@@ -106,7 +108,7 @@ class TestClusterResult(unittest.TestCase):
             # Set hashing may differ from run to run, so turn into sorted arrays
             arr = np.array(list(points))
             arr.sort()
-            #lens.append(arr)
+            # lens.append(arr)
             hash.update(medoid.to_bytes(4, "big"))
             hash.update(arr.data)
 

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -200,7 +200,7 @@ class TestBenchmark(unittest.TestCase):
         genomes = {g.name: g for g in self.reference.genomes}
         pairs = [("C1", "gA"), ("C2", "gA"), ("C4", "gC")]
 
-        for (binname, gname) in pairs:
+        for binname, gname in pairs:
             self.assertEqual(
                 bins[binname].f1(genomes[gname]),
                 bins[binname].fscore(1.0, genomes[gname]),
@@ -314,7 +314,7 @@ class TestBenchmark(unittest.TestCase):
     def test_binning_strain_counter(self):
         # This approach is simple and easy to verify to be correct, but very inefficient.
         # Strain-level counter (level = 0)
-        for ((min_recall, min_precision), n_obs) in self.binning.counters[0].items():
+        for (min_recall, min_precision), n_obs in self.binning.counters[0].items():
             n_exp = 0
             for genome in self.reference.genomes:
                 for bin in self.binning.bins:
@@ -333,9 +333,9 @@ class TestBenchmark(unittest.TestCase):
 
         genomes = {g.name: g for g in self.reference.genomes}
         for rank in (1, 2):
-            for ((min_recall, min_precision), n_obs) in counters[rank].items():
+            for (min_recall, min_precision), n_obs in counters[rank].items():
                 seen = {c: False for c in genomesof[rank - 1]}
-                for (clade, genomenames) in genomesof[rank - 1].items():
+                for clade, genomenames in genomesof[rank - 1].items():
                     for bin in self.binning.bins:
                         rec = 0.0
                         prec = 0.0

--- a/test/test_parsebam.py
+++ b/test/test_parsebam.py
@@ -33,7 +33,9 @@ class TestParseBam(unittest.TestCase):
         cp = CompositionMetaData(m.identifiers, m.lengths, m.mask, m.minlength)
         cp.refhash = b"a" * 32  # write bad refhash
         with self.assertRaises(ValueError):
-            vamb.parsebam.Abundance.from_files(testtools.BAM_FILES, None, cp, True, 0.97, 4)
+            vamb.parsebam.Abundance.from_files(
+                testtools.BAM_FILES, None, cp, True, 0.97, 4
+            )
 
     def test_bad_metadata_mask(self):
         m = self.comp_metadata
@@ -46,7 +48,9 @@ class TestParseBam(unittest.TestCase):
             m.identifiers[:-1], m.lengths[:-1], m.mask[:-3], m.minlength
         )
         with self.assertRaises(ValueError):
-            vamb.parsebam.Abundance.from_files(testtools.BAM_FILES, None, cp, True, 0.97, 4)
+            vamb.parsebam.Abundance.from_files(
+                testtools.BAM_FILES, None, cp, True, 0.97, 4
+            )
 
     def test_badfile(self):
         with self.assertRaises(FileNotFoundError):

--- a/test/test_vambtools.py
+++ b/test/test_vambtools.py
@@ -402,7 +402,7 @@ class TestWriteClusters(unittest.TestCase):
         read = set()
         read_names = set()
 
-        for (k, v) in clusters:
+        for k, v in clusters:
             allcontigs.update(v)
 
         for line in lines:
@@ -410,7 +410,7 @@ class TestWriteClusters(unittest.TestCase):
             printed.add(contig)
             printed_names.add(name)
 
-        for (k, v) in vamb.vambtools.read_clusters(io.StringIO(str)).items():
+        for k, v in vamb.vambtools.read_clusters(io.StringIO(str)).items():
             read.update(v)
             read_names.add(k)
 

--- a/test/testtools.py
+++ b/test/testtools.py
@@ -5,9 +5,9 @@ import vamb
 
 PARENTDIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATADIR = os.path.join(PARENTDIR, "test", "data")
-BAM_FILES = sorted([
-    os.path.join(DATADIR, "bam", i) for i in os.listdir(os.path.join(DATADIR, "bam"))
-])
+BAM_FILES = sorted(
+    [os.path.join(DATADIR, "bam", i) for i in os.listdir(os.path.join(DATADIR, "bam"))]
+)
 
 BAM_NAMES = [
     "S27C175628",

--- a/vamb/__init__.py
+++ b/vamb/__init__.py
@@ -19,7 +19,7 @@ General workflow:
 7) Split bins using vamb.vambtools
 """
 
-__version__ = (4, 0, 2, 'DEV')
+__version__ = (4, 0, 2, "DEV")
 
 from . import vambtools
 from . import parsebam

--- a/vamb/__main__.py
+++ b/vamb/__main__.py
@@ -30,6 +30,7 @@ os.environ["OMP_NUM_THREADS"] = str(DEFAULT_THREADS)
 parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(parentdir)
 
+
 def try_make_dir(name):
     try:
         os.mkdir(name)
@@ -37,6 +38,7 @@ def try_make_dir(name):
         pass
     except:
         raise
+
 
 class FASTAPath(type(Path())):
     pass
@@ -285,7 +287,7 @@ class TrainingOptions:
         lrate: float,
     ):
         assert isinstance(lrate, float)
-        
+
         assert (encoder_options.vae_options is None) == (vae_options is None)
         assert (encoder_options.aae_options is None) == (aae_options is None)
 
@@ -449,7 +451,6 @@ def calc_rpkm(
     nthreads: int,
     logfile: IO[str],
 ) -> vamb.parsebam.Abundance:
-
     begintime = time.time()
     log("\nLoading depths", logfile)
     log(
@@ -461,7 +462,7 @@ def calc_rpkm(
     path = abundance_options.path
     if isinstance(path, AbundancePath):
         log(f"Loading depths from npz array {str(path)}", logfile, 1)
-        
+
         abundance = vamb.parsebam.Abundance.load(
             path, comp_metadata.refhash if abundance_options.refcheck else None
         )
@@ -508,7 +509,6 @@ def trainvae(
     data_loader: DataLoader,
     logfile: IO[str],
 ) -> np.ndarray:
-
     begintime = time.time()
     log("\nCreating and training VAE", logfile)
 
@@ -556,7 +556,6 @@ def trainaae(
     logfile: IO[str],
     contignames: Sequence[str],
 ) -> tuple[np.ndarray, dict[str, set[str]]]:
-
     begintime = time.time()
     log("\nCreating and training AAE", logfile)
     nsamples = data_loader.dataset.tensors[0].shape[1]
@@ -587,7 +586,9 @@ def trainaae(
     print("", file=logfile)
     log("Encoding to latent representation", logfile, 1)
     clusters_y_dict, latent = aae.get_latents(contignames, data_loader)
-    vamb.vambtools.write_npz(os.path.join(vamb_options.out_dir, "aae_z_latent.npz"), latent)
+    vamb.vambtools.write_npz(
+        os.path.join(vamb_options.out_dir, "aae_z_latent.npz"), latent
+    )
 
     del aae  # Needed to free "latent" array's memory references?
 
@@ -749,13 +750,17 @@ def run(
         logfile,
     )
     time_generating_input = round(time.time() - begintime, 2)
-    log(f"\nTNF and coabundances generated in {time_generating_input} seconds.", logfile, 1)
+    log(
+        f"\nTNF and coabundances generated in {time_generating_input} seconds.",
+        logfile,
+        1,
+    )
 
     data_loader, mask = vamb.encode.make_dataloader(
         abundance.matrix,
         composition.matrix,
         composition.metadata.lengths,
-        256, # dummy value - we change this before using the actual loader
+        256,  # dummy value - we change this before using the actual loader
         destroy=True,
         cuda=vamb_options.cuda,
     )
@@ -890,7 +895,9 @@ def run(
         clusterspath = vamb_options.out_dir.joinpath("aae_y_clusters.tsv")
         # Binsplit if given a separator
         if cluster_options.binsplit_separator is not None:
-            maybe_split = vamb.vambtools.binsplit(clusters_y_dict.items(), cluster_options.binsplit_separator)
+            maybe_split = vamb.vambtools.binsplit(
+                clusters_y_dict.items(), cluster_options.binsplit_separator
+            )
         else:
             maybe_split = clusters_y_dict.items()
         with open(clusterspath, "w") as clustersfile:
@@ -925,6 +932,7 @@ def run(
 
     log(f"\nCompleted Vamb in {round(time.time() - begintime, 2)} seconds.", logfile, 0)
 
+
 def main():
     doc = f"""Avamb: Adversarial and Variational autoencoders for metagenomic binning.
     
@@ -955,11 +963,11 @@ def main():
     # Positional arguments
     reqos = parser.add_argument_group(title="Output (required)", description=None)
     reqos.add_argument(
-        "--outdir", 
+        "--outdir",
         metavar="",
-        type=Path, 
-        required=True, 
-        help="output directory to create"
+        type=Path,
+        required=True,
+        help="output directory to create",
     )
 
     # TNF arguments
@@ -967,26 +975,28 @@ def main():
         title="TNF input (either fasta or all .npz files required)"
     )
     tnfos.add_argument("--fasta", metavar="", type=Path, help="path to fasta file")
-    tnfos.add_argument("--composition", metavar="",type=Path, help="path to .npz of composition")
+    tnfos.add_argument(
+        "--composition", metavar="", type=Path, help="path to .npz of composition"
+    )
 
     # RPKM arguments
     rpkmos = parser.add_argument_group(
         title="RPKM input (either BAMs or .npz required)"
     )
     rpkmos.add_argument(
-        "--bamfiles", 
-        dest='bampaths',
-        metavar="", 
+        "--bamfiles",
+        dest="bampaths",
+        metavar="",
         type=Path,
-        help="paths to (multiple) BAM files", 
-        nargs="+"
+        help="paths to (multiple) BAM files",
+        nargs="+",
     )
     rpkmos.add_argument(
-        "--rpkm", 
+        "--rpkm",
         metavar="",
         dest="abundancepath",
-        type=Path,  
-        help="path to .npz of RPKM (abundances)"
+        type=Path,
+        help="path to .npz of RPKM (abundances)",
     )
 
     # Optional arguments
@@ -1255,16 +1265,12 @@ def main():
 
     args = parser.parse_args()
 
-    comp_options = CompositionOptions(
-        args.fasta, args.composition, args.minlength
-
-    )
+    comp_options = CompositionOptions(args.fasta, args.composition, args.minlength)
 
     abundance_options = AbundanceOptions(
         args.bampaths,
         args.abundancepath,
         args.min_alignment_id,
-
         not args.norefcheck,
     )
 
@@ -1284,16 +1290,18 @@ def main():
         vae_options = None
         vae_training_options = None
 
-        for (name, arg, default) in [
+        for name, arg, default in [
             ("-n", args.nhiddens, None),
             ("-l", args.nlatent, 32),
             ("-b", args.beta, 200.0),
             ("-d", args.dropout, None),
             ("-t", args.batchsize, 256),
-            ("-q", args.batchsteps, [25, 75, 150, 225])
+            ("-q", args.batchsteps, [25, 75, 150, 225]),
         ]:
             if arg != default:
-                raise ValueError(f"VAE model not used, but VAE-specific arg \"{name}\" used")
+                raise ValueError(
+                    f'VAE model not used, but VAE-specific arg "{name}" used'
+                )
 
     if args.model in ("aae", "vae-aae"):
         aae_options = AAEOptions(
@@ -1315,7 +1323,7 @@ def main():
         aae_options = None
         aae_training_options = None
 
-        for (name, arg, default) in [
+        for name, arg, default in [
             ("--n_aae", args.nhiddens_aae, 547),
             ("--z_aae", args.nlatent_aae_z, 283),
             ("--y_aae", args.nlatent_aae_y, 700),
@@ -1327,7 +1335,9 @@ def main():
             ("--q_aae", args.batchsteps_aae, [25, 50]),
         ]:
             if arg != default:
-                raise ValueError(f"AAE model not used, but AAE-specific arg \"{name}\" used")
+                raise ValueError(
+                    f'AAE model not used, but AAE-specific arg "{name}" used'
+                )
 
     encoder_options = EncoderOptions(
         vae_options=vae_options, aae_options=aae_options, alpha=args.alpha

--- a/vamb/aamb_encode.py
+++ b/vamb/aamb_encode.py
@@ -22,6 +22,7 @@ torch.backends.cudnn.deterministic = True
 torch.backends.cudnn.benchmark = False
 np.random.seed(random_seed)
 
+
 ############################################################################# MODEL ###########################################################
 class AAE(nn.Module):
     def __init__(
@@ -105,7 +106,6 @@ class AAE(nn.Module):
 
     ## Reparametrisation trick
     def _reparameterization(self, mu, logvar):
-
         Tensor = torch.cuda.FloatTensor if self.usecuda else torch.FloatTensor
 
         std = torch.exp(logvar / 2)
@@ -198,7 +198,6 @@ class AAE(nn.Module):
         logfile: Optional[IO[str]] = None,
         modelfile: Union[None, str, IO[bytes]] = None,
     ):
-
         Tensor = torch.cuda.FloatTensor if self.usecuda else torch.FloatTensor
         batchsteps_set = set(batchsteps)
         ncontigs, _ = data_loader.dataset.tensors[0].shape
@@ -426,7 +425,9 @@ class AAE(nn.Module):
         return None
 
     ########### funciton that retrieves the clusters from Y latents
-    def get_latents(self, contignames: Sequence[str], data_loader, last_epoch: bool = True):
+    def get_latents(
+        self, contignames: Sequence[str], data_loader, last_epoch: bool = True
+    ):
         """Retrieve the categorical latent representation (y) and the contiouous latents (l) of the inputs
 
         Inputs:
@@ -450,7 +451,6 @@ class AAE(nn.Module):
         clust_y_dict = dict()
         Tensor = torch.cuda.FloatTensor if self.usecuda else torch.FloatTensor
         with torch.no_grad():
-
             for depths_in, tnfs_in, _ in new_data_loader:
                 nrows, _ = depths_in.shape
                 if self.usecuda:
@@ -475,9 +475,7 @@ class AAE(nn.Module):
                     tnfs_in = tnfs_in.cuda()
 
                 if last_epoch:
-                    mu, _, _, _, y_sample = self(depths_in, tnfs_in)[
-                        0:5
-                    ]
+                    mu, _, _, _, y_sample = self(depths_in, tnfs_in)[0:5]
                 else:
                     y_sample = self(depths_in, tnfs_in)[4]
 

--- a/vamb/benchmark.py
+++ b/vamb/benchmark.py
@@ -231,7 +231,7 @@ class Bin:
         by_source: defaultdict[tuple[Genome, str], list[Contig]] = defaultdict(list)
         for contig in self.contigs:
             by_source[(genomeof[contig], contig.subject)].append(contig)
-        for ((genome, _), contigs) in by_source.items():
+        for (genome, _), contigs in by_source.items():
             self.intersections[genome] = self.intersections.get(
                 genome, 0
             ) + self._intersection(contigs)
@@ -353,7 +353,7 @@ class Reference:
     def load_bins(self, bins: Iterable[tuple[str, Iterable[str]]]) -> list[Bin]:
         """Convert a set of bin names to a list of Bins"""
         result: list[Bin] = list()
-        for (binname, contignames) in bins:
+        for binname, contignames in bins:
             contigs = (self.contig_by_name[name] for name in contignames)
             result.append(Bin.from_contigs(binname, contigs, self.genomeof))
 
@@ -367,12 +367,12 @@ class Reference:
     @classmethod
     def from_dict(cls: type[R], json_dict: dict[str, Any]) -> R:
         instance = cls()
-        for (genomename, sourcesdict) in json_dict["genomes"].items():
+        for genomename, sourcesdict in json_dict["genomes"].items():
             genome = Genome(genomename)
             instance._add_genome(genome)
-            for (sourcename, (sourcelen, contigdict)) in sourcesdict.items():
+            for sourcename, (sourcelen, contigdict) in sourcesdict.items():
                 genome.add(sourcename, sourcelen)
-                for (contigname, (start, end)) in contigdict.items():
+                for contigname, (start, end) in contigdict.items():
                     # JSON format is 1-indexed and includes endpoints, whereas
                     # Contig struct is not, so compensate.
                     contig = Contig(contigname, sourcename, start - 1, end)
@@ -380,8 +380,8 @@ class Reference:
 
         for _ in range(len(json_dict["taxmaps"]) - 1):
             instance.taxmaps.append(dict())
-        for (level, taxmap) in enumerate(json_dict["taxmaps"]):
-            for (child, parent) in taxmap.items():
+        for level, taxmap in enumerate(json_dict["taxmaps"]):
+            for child, parent in taxmap.items():
                 instance._add_taxonomy(level, child, parent)
 
         return instance
@@ -394,10 +394,10 @@ class Reference:
         for genome in self.genomes:
             source_dict: dict[str, list[Any]] = dict()
             genome_dict[genome.name] = source_dict
-            for (sourcename, length) in genome.sources.items():
+            for sourcename, length in genome.sources.items():
                 source_dict[sourcename] = [length, dict()]
 
-        for (contig, genome) in self.genomeof.items():
+        for contig, genome in self.genomeof.items():
             # JSON format is 1-indexes and includes endpoints, whereas
             # Contig struct is not, so compensate.
             genome_dict[genome.name][contig.subject][1][contig.name] = [
@@ -407,7 +407,7 @@ class Reference:
 
         for taxmap in self.taxmaps:
             d: dict[str, str] = dict()
-            for (child, parent) in taxmap.items():
+            for child, parent in taxmap.items():
                 if parent is not None:
                     d[child] = parent
             if len(d) > 0:
@@ -581,10 +581,10 @@ class Binning:
         precisions: tuple[float] = self.precisions
         bitvectors: dict[str, int] = dict()
 
-        for (cladename, d) in rp_by_name.items():
+        for cladename, d in rp_by_name.items():
             bitvector = 0
-            for (recall, precision) in d.values():
-                for (i, (min_recall, min_precision)) in enumerate(
+            for recall, precision in d.values():
+                for i, (min_recall, min_precision) in enumerate(
                     product(recalls, precisions)
                 ):
                     if recall >= min_recall and precision >= min_precision:
@@ -605,8 +605,8 @@ class Binning:
         result: dict[tuple[float, float], int] = {
             (r, p): 0 for (r, p) in product(recalls, precisions)
         }
-        for (_, bitvector) in bitvectors.items():
-            for (i, rp) in enumerate(product(recalls, precisions)):
+        for _, bitvector in bitvectors.items():
+            for i, rp in enumerate(product(recalls, precisions)):
                 result[rp] += (bitvector >> i) & 1
 
         return result
@@ -615,7 +615,7 @@ class Binning:
         self, fromrank: int, rp_by_name: dict[str, dict[Bin, tuple[float, float]]]
     ) -> dict[str, dict[Bin, tuple[float, float]]]:
         result: dict[str, dict[Bin, tuple[float, float]]] = dict()
-        for (child, parent) in self.reference.taxmaps[fromrank].items():
+        for child, parent in self.reference.taxmaps[fromrank].items():
             # If no parent clade, we just name the "parent" same as child
             if parent is None:
                 parent = child
@@ -624,7 +624,7 @@ class Binning:
                 result[parent] = dict()
 
             parent_dict = result[parent]
-            for (bin, (old_recall, old_prec)) in rp_by_name[child].items():
+            for bin, (old_recall, old_prec) in rp_by_name[child].items():
                 (new_recall, new_prec) = parent_dict.get(bin, (0.0, 0.0))
                 parent_dict[bin] = (max(old_recall, new_recall), old_prec + new_prec)
 

--- a/vamb/cluster.py
+++ b/vamb/cluster.py
@@ -452,7 +452,8 @@ def _smaller_indices(
     tensor: _Tensor, kept_mask: _Tensor, threshold: float, cuda: bool
 ) -> _Tensor:
     """Get all indices where the tensor is smaller than the threshold.
-    Uses Numpy because Torch is slow - See https://github.com/pytorch/pytorch/pull/15190"""
+    Uses Numpy because Torch is slow - See https://github.com/pytorch/pytorch/pull/15190
+    """
 
     # If it's on GPU, we remove the already clustered points at this step.
     if cuda:

--- a/vamb/encode.py
+++ b/vamb/encode.py
@@ -30,7 +30,10 @@ import torch as _torch
 
 _torch.manual_seed(0)
 
-def set_batchsize(data_loader: _DataLoader, batch_size: int, encode=False) -> _DataLoader:
+
+def set_batchsize(
+    data_loader: _DataLoader, batch_size: int, encode=False
+) -> _DataLoader:
     """Effectively copy the data loader, but with a different batch size.
 
     The `encode` option is used to copy the dataloader to use before encoding.
@@ -39,12 +42,13 @@ def set_batchsize(data_loader: _DataLoader, batch_size: int, encode=False) -> _D
     """
     return _DataLoader(
         dataset=data_loader.dataset,
-        batch_size= batch_size,
+        batch_size=batch_size,
         shuffle=not encode,
         drop_last=not encode,
         num_workers=1 if encode else data_loader.num_workers,
         pin_memory=data_loader.pin_memory,
     )
+
 
 def make_dataloader(
     rpkm: _np.ndarray,
@@ -373,7 +377,7 @@ class VAE(_nn.Module):
         epoch_celoss = 0.0
 
         if epoch in batchsteps:
-            data_loader =  set_batchsize(data_loader, data_loader.batch_size * 2)
+            data_loader = set_batchsize(data_loader, data_loader.batch_size * 2)
 
         for depths_in, tnf_in, weights in data_loader:
             depths_in.requires_grad = True
@@ -428,7 +432,9 @@ class VAE(_nn.Module):
 
         self.eval()
 
-        new_data_loader = set_batchsize(data_loader, data_loader.batch_size, encode=True)
+        new_data_loader = set_batchsize(
+            data_loader, data_loader.batch_size, encode=True
+        )
 
         depths_array, _, _ = data_loader.dataset.tensors
         length = len(depths_array)

--- a/vamb/parsebam.py
+++ b/vamb/parsebam.py
@@ -176,7 +176,7 @@ class Abundance:
 
         # Load from BAM and store them chunkwise
         refhash = None
-        for (filename, (chunkstart, chunkstop)) in zip(filenames, chunks):
+        for filename, (chunkstart, chunkstop) in zip(filenames, chunks):
             (matrix, refhash) = cls.run_pycoverm(
                 paths[chunkstart:chunkstop],
                 minid,
@@ -187,7 +187,7 @@ class Abundance:
 
         # Initialize matrix, the load them chunkwise. Delete the temp files when done
         matrix = _np.empty((mask.sum(), len(paths)), dtype=_np.float32)
-        for (filename, (chunkstart, chunkstop)) in zip(filenames, chunks):
+        for filename, (chunkstart, chunkstop) in zip(filenames, chunks):
             matrix[:, chunkstart:chunkstop] = vambtools.read_npz(filename)
 
         shutil.rmtree(cache_directory)

--- a/vamb/vambtools.py
+++ b/vamb/vambtools.py
@@ -434,7 +434,7 @@ def write_bins(
         fastaio: bytes iterator containing FASTA file with all sequences
         maxbins: None or else raise an error if trying to make more bins than this [250]
         minsize: Minimum number of nucleotides in cluster to be output [0]
-        separator: string that separates the contig/cluster name from the sample ; i.e. sample_id_separator_contig_name/cluster_name 
+        separator: string that separates the contig/cluster name from the sample ; i.e. sample_id_separator_contig_name/cluster_name
     Output: None
     """
 
@@ -493,7 +493,7 @@ def write_bins(
 
         # Split bin files into sample dirs
         if binsample is not None:
-            bin_dir = _os.path.join(directory,binsample)
+            bin_dir = _os.path.join(directory, binsample)
             try:
                 _os.mkdir(bin_dir)
             except FileExistsError:
@@ -502,7 +502,7 @@ def write_bins(
                 raise
         else:
             bin_dir = directory
-    
+
         # Print bin to file
         filename = _os.path.join(bin_dir, binname + ".fna")
 
@@ -566,10 +566,9 @@ def concatenate_fasta(
     """
 
     identifiers: set[str] = set()
-    for (inpathno, inpath) in enumerate(inpaths):
+    for inpathno, inpath in enumerate(inpaths):
         try:
             with Reader(inpath) as infile:
-
                 # If we rename, seq identifiers only have to be unique for each sample
                 if rename:
                     identifiers.clear()

--- a/workflow_avamb/src/abundances_mask.py
+++ b/workflow_avamb/src/abundances_mask.py
@@ -1,50 +1,40 @@
-import numpy as np 
-import argparse 
+import numpy as np
+import argparse
 from vamb.vambtools import hash_refnames
 from pathlib import Path
 
+
 def abundances_mask(headers: Path, mask_refhash: Path, min_contig_size: int):
     """# Using the headers above, compute the mask and the refhash"""
-    
+
     mask = []
     identifiers = []
-    
+
     with open(headers) as file:
         for line in file:
             # SN:S27C112075   LN:2239
-            (sn, ln) = line.split('\t')
+            (sn, ln) = line.split("\t")
             if sn[:3] != "SN:" or ln[:3] != "LN:":
                 raise ValueError("Unknown format")
             passed = int(ln[3:]) >= min_contig_size
             mask.append(passed)
-            if passed: 
+            if passed:
                 identifiers.append(sn[3:])
 
     np.savez_compressed(
         mask_refhash,
         mask=np.array(mask, dtype=bool),
-        refhash=hash_refnames(identifiers)
+        refhash=hash_refnames(identifiers),
     )
-    
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--h", type=Path, help=" Headers file")
     parser.add_argument("--msk", type=Path, help="mask refhash")
-    
-    parser.add_argument(
-        "--minsize", type=int, help="min contig size"
-    )
+
+    parser.add_argument("--minsize", type=int, help="min contig size")
 
     opt = parser.parse_args()
 
-
-    abundances_mask(
-        opt.h,
-        opt.msk,
-        opt.minsize
-              
-                    )
-
-
+    abundances_mask(opt.h, opt.msk, opt.minsize)

--- a/workflow_avamb/src/create_abundances.py
+++ b/workflow_avamb/src/create_abundances.py
@@ -1,21 +1,23 @@
-import numpy as np 
-import argparse 
+import numpy as np
+import argparse
 import vamb
 from pathlib import Path
 
 
-def create_abundances(abundances: list[Path], mask_refhash: Path, min_id: float, outfile: Path):
+def create_abundances(
+    abundances: list[Path], mask_refhash: Path, min_id: float, outfile: Path
+):
     """Merge the abundances to a single Abundance object and save it"""
     refhash = np.load(mask_refhash)["refhash"]
-    
+
     n_samples = len(abundances)
     first = vamb.vambtools.read_npz(abundances[0])
     print(len(first), n_samples)
     print(first.shape)
     matrix = np.empty((len(first), n_samples), dtype=np.float32)
     matrix[:, 0] = first
-    for (i, path) in enumerate(abundances[1:]):
-        matrix[:, i+1] = vamb.vambtools.read_npz(path)
+    for i, path in enumerate(abundances[1:]):
+        matrix[:, i + 1] = vamb.vambtools.read_npz(path)
     abundance = vamb.parsebam.Abundance(
         matrix, [str(i) for i in abundances], min_id, refhash
     )
@@ -26,20 +28,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--msk", type=Path, help="mask refhash")
     parser.add_argument("--ab", type=Path, nargs="+", help=" abundancaes list of files")
-    parser.add_argument(
-        "--min_id", type=float, help="min identity for alignment"
-    )
-    parser.add_argument(
-        "--out", type=Path, help="abundances outfile"
-    )
+    parser.add_argument("--min_id", type=float, help="min identity for alignment")
+    parser.add_argument("--out", type=Path, help="abundances outfile")
 
     opt = parser.parse_args()
 
-
-    create_abundances(
-        opt.ab,
-        opt.msk,
-        opt.min_id,
-        opt.out
-              
-                    )
+    create_abundances(opt.ab, opt.msk, opt.min_id, opt.out)

--- a/workflow_avamb/src/manual_drep_JN.py
+++ b/workflow_avamb/src/manual_drep_JN.py
@@ -122,7 +122,7 @@ def load_binnings(
     Return bin length and bins, each represented as a set of ContigId
     """
     id_len_of_contig_name: dict[str, tuple[ContigId, int]] = dict()
-    for (index, (name, length)) in enumerate(zip(contig_names, lengths)):
+    for index, (name, length) in enumerate(zip(contig_names, lengths)):
         id_len_of_contig_name[name] = (ContigId(index), length)
 
     # Load binnings
@@ -136,8 +136,7 @@ def load_binnings(
             clusters = vamb.vambtools.read_clusters(file)
             clusters_filtered = filterclusters(clusters, lengthof)
             # filter by clusters larger than 200kbs
-            for (bin_name, contigs) in clusters_filtered.items():
-
+            for bin_name, contigs in clusters_filtered.items():
                 bin_name += ".fna"
                 # None is a valid value, so we use -1 as sentinel for missing
                 bin = bin_by_name.get(bin_name, -1)
@@ -205,7 +204,7 @@ def dereplicate(
 def get_binsof(union_bins: Iterable[Iterable[ContigId]]) -> dict[ContigId, list[BinId]]:
     "Makes a dict from contig -> list of bins the contig is present in, if in multiple bins"
     binsof: dict[ContigId, Union[BinId, list[BinId]]] = dict()
-    for (bin_int, contigs) in enumerate(union_bins):
+    for bin_int, contigs in enumerate(union_bins):
         bin = BinId(bin_int)
         for contig in contigs:
             existing = binsof.get(contig)
@@ -222,13 +221,14 @@ def get_binsof(union_bins: Iterable[Iterable[ContigId]]) -> dict[ContigId, list[
 def bin_score(completeness: float, contamination: float) -> float:
     return completeness - 5 * contamination
 
+
 def get_overlapping_bin_pairs(
     binsof: Mapping[ContigId, list[BinId]], qualities: Sequence[tuple[float, float]]
 ) -> Sequence[tuple[BinId, BinId]]:
     "Get a list of pairs of bins that share at least one contig"
     pairs: set[tuple[BinId, BinId]] = set()
     for overlapping_bins in binsof.values():
-        for (a, b) in itertools.combinations(overlapping_bins, r=2):
+        for a, b in itertools.combinations(overlapping_bins, r=2):
             # Order them so we don't have (a, b) and (b, a) as distinct pairs
             if a > b:
                 (a, b) = (b, a)
@@ -238,7 +238,7 @@ def get_overlapping_bin_pairs(
     # If they tie, then use lexographic order (a, b) we added them
     # in above
     result: list[tuple[BinId, BinId]] = []
-    for (a, b) in pairs:
+    for a, b in pairs:
         score_a = bin_score(*qualities[a])
         score_b = bin_score(*qualities[b])
         if score_a > score_b:
@@ -258,7 +258,7 @@ def compute_to_remove(
 ) -> set[BinId]:
     "Create a list of bins to remove because they overlap with another bin"
     result: set[BinId] = set()
-    for (bin_a, bin_b) in overlapping_pairs:
+    for bin_a, bin_b in overlapping_pairs:
         if bin_a in result or bin_b in result:
             continue
 

--- a/workflow_avamb/src/mv_bins_from_mdrep_clusters.py
+++ b/workflow_avamb/src/mv_bins_from_mdrep_clusters.py
@@ -17,7 +17,6 @@ def main(
     min_comp: float = 0.9,
     max_cont: float = 0.05,
 ):
-
     cluster_sample = get_cluster_sample(cluster_contigs, bin_separator)
     nc_cluster_scores = get_nc_cluster_scores(
         cluster_scores, cluster_sample, min_comp, max_cont
@@ -69,7 +68,6 @@ def create_nc_sample_folders(
 ):
     nc_samples: set[str] = set()
     for cluster in cluster_scores.keys():
-
         sample = cluster_sample[cluster]
         nc_samples.add(sample)
 
@@ -86,7 +84,6 @@ def write_nc_bins_from_mdrep_clusters(
     path_nc_bins_folder: str,
     path_bins_folder: str,
 ):
-
     for cluster in cluster_scores.keys():
         sample = cluster_sample[cluster]
         src_bin = os.path.join(path_bins_folder, sample, cluster + ".fna")

--- a/workflow_avamb/src/rip_bins.py
+++ b/workflow_avamb/src/rip_bins.py
@@ -19,7 +19,6 @@ def main(
     path_ripped: str,
     path_clusters_not_ripped: str,
 ) -> dict[str, str]:
-
     cluster_contigs_original = cluster_contigs.copy()
 
     contig_length = get_contig_length(contig_names, contig_lengths)
@@ -47,9 +46,12 @@ def main(
         graph_clusters, cluster_contigs, bin_path, path_ripped
     )
 
-
-    clusters_changed_but_not_intersecting_contigs_total = clusters_changed_but_not_intersecting_contigs.copy()
-    clusters_changed_but_not_intersecting_contigs_total.update(clusters_changed_but_not_intersecting_contigs_2)
+    clusters_changed_but_not_intersecting_contigs_total = (
+        clusters_changed_but_not_intersecting_contigs.copy()
+    )
+    clusters_changed_but_not_intersecting_contigs_total.update(
+        clusters_changed_but_not_intersecting_contigs_2
+    )
 
     (
         bin_path,
@@ -88,7 +90,7 @@ def get_cluster_length(
     cluster_contigs: dict[str, set[str]], contig_length: dict[str, int]
 ) -> OrderedDict[str, int]:
     cluster_length: OrderedDict[str, int] = OrderedDict()
-    for (cluster_name, contigs) in cluster_contigs.items():
+    for cluster_name, contigs in cluster_contigs.items():
         cluster_length[cluster_name] = 0
         for contig in contigs:
             cluster_length[cluster_name] += contig_length[contig]
@@ -101,7 +103,8 @@ def get_graph_clusters(
     cluster_length: OrderedDict[str, int],
 ):
     """Generate a graph where each cluster is a node and each edge connecting 2 nodes is
-    created if clusters share some contigs, edges are weighted by the intersection length"""
+    created if clusters share some contigs, edges are weighted by the intersection length
+    """
     graph_clusters = nx.Graph()
     for i, cluster_i in enumerate(cluster_contigs.keys()):
         for j, cluster_j in enumerate(cluster_contigs.keys()):
@@ -240,7 +243,8 @@ def make_all_components_pair(
 ):
     """Iterate over all graph components that contain more than 2 nodes/clusters and break them down to
     2 nodes/clusters components according the following criteria:
-        - Remove the weaker edge by removing the intersecting contigs from the larger cluster"""
+        - Remove the weaker edge by removing the intersecting contigs from the larger cluster
+    """
 
     components: list[set[str]] = list()
     for component in nx.connected_components(graph_clusters):
@@ -257,7 +261,7 @@ def make_all_components_pair(
                             cl_i, cl_j
                         )["weight"]
                         # if the weight as key in the dict and is mapping to different clusters (nodes)
-                        # then add a insignificant value to the weight so we can add the weight with 
+                        # then add a insignificant value to the weight so we can add the weight with
                         # different clusters (nodes)
                         if (
                             cl_i_cl_j_edge_weight in weight_edges.keys()
@@ -265,19 +269,22 @@ def make_all_components_pair(
                         ):
                             cl_i_cl_j_edge_weight += 1 * 10**-30
                         weight_edges[cl_i_cl_j_edge_weight] = {cl_i, cl_j}
-                        
-
 
             dsc_sorted_weights: list[float] = sorted(list(weight_edges.keys()))
-            
+
             i = 0
             component_len = len(component)
-             
-            print(dsc_sorted_weights,len(dsc_sorted_weights), len(component),weight_edges.keys())
+
+            print(
+                dsc_sorted_weights,
+                len(dsc_sorted_weights),
+                len(component),
+                weight_edges.keys(),
+            )
             while component_len > 2:
                 weight_i = dsc_sorted_weights[i]
                 cl_i, cl_j = weight_edges[weight_i]
-                print(weight_i,cl_i, cl_j)
+                print(weight_i, cl_i, cl_j)
                 cluster_updated = move_intersection_to_smaller_cluster(
                     graph_clusters,
                     cl_i,
@@ -298,7 +305,6 @@ def make_all_components_pair(
                 )
 
                 i += 1
-            
 
     components: list[set[str]] = list()
     for component in nx.connected_components(graph_clusters):

--- a/workflow_avamb/src/transfer_contigs_and_aggregate_all_nc_bins.py
+++ b/workflow_avamb/src/transfer_contigs_and_aggregate_all_nc_bins.py
@@ -21,7 +21,6 @@ def main(
     min_comp,
     max_cont,
 ):
-
     # {cluster:sample} dictionary for the manually drep clusters
     cluster_sample = get_cluster_sample(cluster_contigs, bin_separator)
     for sample in set(cluster_sample.values()):
@@ -33,7 +32,13 @@ def main(
     # Given all the clusters that have no connection (no intersection) with any other cluster
     # mv them to the final bins folder that contains the final set of NC bins if they are NC
     nc_clusters_unchanged = mv_nc_not_r_nc_bins(
-        cluster_not_r_contigs, cluster_sample, cluster_scores, drep_folder, bin_path, min_comp, max_cont
+        cluster_not_r_contigs,
+        cluster_sample,
+        cluster_scores,
+        drep_folder,
+        bin_path,
+        min_comp,
+        max_cont,
     )
 
     # Given the checkM2 scores for all ripped bins, create a dictionary
@@ -52,7 +57,7 @@ def main(
         path_run,
         path_bins_ripped,
         min_comp,
-        max_cont
+        max_cont,
     )
 
     # for the bins that have been ripped because of meaningless edges and after the ripping present
@@ -95,15 +100,19 @@ def get_cluster_sample(cluster_contigs, bin_separator):
 
 
 def mv_nc_not_r_nc_bins(
-    cluster_not_r_contigs, cluster_sample, cluster_scores, drep_folder, bin_path, min_comp, max_cont
+    cluster_not_r_contigs,
+    cluster_sample,
+    cluster_scores,
+    drep_folder,
+    bin_path,
+    min_comp,
+    max_cont,
 ):
-
     """mv not ripped NC bins from bins folder to drep folder"""
     nc_clusters_unchanged = set()
     for cluster in cluster_not_r_contigs.keys():
         comp, cont = cluster_scores[cluster]
         if comp >= min_comp and cont <= max_cont:
-
             # src_bin=os.path.join(path_bins,cluster_sample[cluster],cluster+'.fna')
             src_bin = bin_path[cluster + ".fna"]
             trg_bin = os.path.join(
@@ -113,9 +122,7 @@ def mv_nc_not_r_nc_bins(
                 "Bin %s has no intersection with any other bin so it is directly moved from %s to %s"
                 % (cluster, src_bin, trg_bin)
             )
-            shutil.move(
-                src_bin, trg_bin
-            )  
+            shutil.move(src_bin, trg_bin)
 
             nc_clusters_unchanged.add(cluster)
     return nc_clusters_unchanged
@@ -134,7 +141,7 @@ def mv_single_ripped_nc_bins(
     path_run,
     cluster_sample,
     min_comp,
-    max_cont
+    max_cont,
 ):
     """Mv nc bins that were ripped only because they had meaningless edges"""
     nc_clusters_ripped_single = set()
@@ -148,10 +155,10 @@ def mv_single_ripped_nc_bins(
 
         comp, cont = float(comp), float(cont)
         comp_, cont_ = cluster_score[cluster]
-        
+
         assert comp == comp_
         assert cont == cont_
-        
+
         if comp >= min_comp and cont <= max_cont:
             src_bin = bin_path[cluster + ".fna"]
 
@@ -164,7 +171,6 @@ def mv_single_ripped_nc_bins(
                     % (cluster, src_bin, trg_bin)
                 )
                 shutil.move(src_bin, trg_bin)
-
 
                 nc_clusters_ripped_single.add(cluster)
     return nc_clusters_ripped_single
@@ -202,14 +208,12 @@ def choose_best_ripped_bin_and_mv_if_nc(
     path_run,
     path_bins_ripped,
     min_comp,
-    max_cont
+    max_cont,
 ):
-
     nc_clusters_unchanged, nc_clusters_ripped = set(), set()
     clusters_already_processed = set()
     """So given 2 ripped bins that miss the interseciton, we have to choose who keeps the contigs"""
     for cluster_A_r, cluster_B_r in cluster_r_pairs:
-
         if (
             cluster_A_r in clusters_already_processed
             or cluster_B_r in clusters_already_processed
@@ -385,6 +389,6 @@ if __name__ == "__main__":
         bin_path,
         path_bins_ripped,
         bin_separator,
-        opt.comp*100,
-        opt.cont*100,
+        opt.comp * 100,
+        opt.cont * 100,
     )

--- a/workflow_avamb/src/workflow_tools.py
+++ b/workflow_avamb/src/workflow_tools.py
@@ -37,7 +37,7 @@ def get_cluster_score_bin_path(
 
 def update_cluster_score_bin_path(
     path_checkm_ripped: str, cluster_score: dict[str, tuple[float, float]]
-) -> dict[str, tuple[float,float]] :
+) -> dict[str, tuple[float, float]]:
     c_com_con = np.loadtxt(
         path_checkm_ripped,
         delimiter="\t",

--- a/workflow_avamb/src/write_abundances.py
+++ b/workflow_avamb/src/write_abundances.py
@@ -1,45 +1,30 @@
-import numpy as np 
-import argparse 
+import numpy as np
+import argparse
 import vamb
 from pathlib import Path
 
 
-def write_abundances(mask_refhash: Path,bampath: Path,min_identity: float, outfile: Path):
+def write_abundances(
+    mask_refhash: Path, bampath: Path, min_identity: float, outfile: Path
+):
     """For every sample, compute the abundances given the mask and refhashes"""
     loadnpz = np.load(mask_refhash)
     refhash = loadnpz["refhash"]
     mask = loadnpz["mask"]
     refhash = refhash.reshape(1)[0]
     (abundance, _) = vamb.parsebam.Abundance.run_pycoverm(
-        paths=[bampath],
-        minid=min_identity,
-        target_refhash=refhash,
-        mask=mask
+        paths=[bampath], minid=min_identity, target_refhash=refhash, mask=mask
     )
     vamb.vambtools.write_npz(outfile, abundance.ravel())
-
-
-
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--msk", type=Path, help="mask refhash")
     parser.add_argument("--b", type=Path, help=" bam path")
-    parser.add_argument(
-        "--min_id", type=float, help="min identity for alignment"
-    )
-    parser.add_argument(
-        "--out", type=Path, help="abundances outfile"
-    )
+    parser.add_argument("--min_id", type=float, help="min identity for alignment")
+    parser.add_argument("--out", type=Path, help="abundances outfile")
 
     opt = parser.parse_args()
 
-
-    write_abundances(
-        opt.msk,
-        opt.b,
-        opt.min_id,
-        opt.out
-              
-                    )
+    write_abundances(opt.msk, opt.b, opt.min_id, opt.out)


### PR DESCRIPTION
The only real change here is the addition of `.github/workflows/black.yml`. This will test for each PR that the code is formatted according to the [Black formatter](https://black.readthedocs.io/en/stable/).
All the remaining changes are simply from running Black on this repo.

To make your PRs pass, simply install `black` from pip, then call `black .` when in the Vamb repo to format all your files.

This might be too invasive, but let's see. We can always revert it.

See also commits e6480ce and 5a0cc3a, the likes of which this PR is intended to make obsolete.