### PR TITLE
Allow setting random seed from command line

### DIFF
--- a/vamb/cluster.py
+++ b/vamb/cluster.py
@@ -206,6 +206,7 @@ class ClusterGenerator:
         destroy: bool = False,
         normalized: bool = False,
         cuda: bool = False,
+        seed: int = 0,
     ):
         self._check_params(matrix, maxsteps, windowsize, minsuccesses)
         if not destroy:
@@ -213,8 +214,8 @@ class ClusterGenerator:
 
         # Shuffle matrix in unison to prevent seed sampling bias. Indices keeps
         # track of which points are which.
-        _np.random.RandomState(0).shuffle(matrix)
-        indices = _np.random.RandomState(0).permutation(len(matrix))
+        _np.random.Generator(_np.random.PCG64(seed)).shuffle(matrix)
+        indices = _np.random.Generator(_np.random.PCG64(seed)).permutation(len(matrix))
         indices = _torch.from_numpy(indices)
         torch_matrix = _torch.from_numpy(matrix)
 
@@ -228,7 +229,7 @@ class ClusterGenerator:
         self.maxsteps: int = maxsteps
         self.minsuccesses: int = minsuccesses
         self.cuda: bool = cuda
-        self.rng: _random.Random = _random.Random(0)
+        self.rng: _random.Random = _random.Random(seed)
 
         self.matrix = torch_matrix
         # This refers to the indices of the original matrix. As we remove points, these

--- a/vamb/encode.py
+++ b/vamb/encode.py
@@ -28,8 +28,6 @@ __cmd_doc__ = """Encode depths and TNF using a VAE to latent representation"""
 import numpy as _np
 import torch as _torch
 
-_torch.manual_seed(0)
-
 
 def set_batchsize(
     data_loader: _DataLoader, batch_size: int, encode=False
@@ -191,6 +189,7 @@ class VAE(_nn.Module):
         beta: float = 200.0,
         dropout: Optional[float] = 0.2,
         cuda: bool = False,
+        seed: int = 0,
     ):
         if nlatent < 1:
             raise ValueError(f"Minimum 1 latent neuron, not {nlatent}")
@@ -220,6 +219,7 @@ class VAE(_nn.Module):
         if not (0 <= dropout < 1):
             raise ValueError(f"dropout must be 0 <= dropout < 1, not {dropout}")
 
+        _torch.manual_seed(seed)
         super(VAE, self).__init__()
 
         # Initialize simple attributes


### PR DESCRIPTION
We currently default to seed 0, but some uses may want to use random seeds. Note that Vamb behaviour is not guaranteed to be preserved even with the same seed, because a) PyTorch is nondeterministic at this point, and b) We do not care to fix the versions of NumPy to prevent updates to the underlying RNG.