### PR TITLE
Bugfix: Create out_dir/tmp in parsebam if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v4.1.1
+* Create tmp directory in parsebam if needed for pycoverm (issue # 167)
+
 ## v4.1.0
 * Fix typo in output AAE_Z cluster names. They are now called e.g. "aae_z_1"
   instead of "aae_z1"

--- a/vamb/__init__.py
+++ b/vamb/__init__.py
@@ -19,7 +19,7 @@ General workflow:
 7) Split bins using vamb.vambtools
 """
 
-__version__ = (4, 1, 0)
+__version__ = (4, 1, 1)
 
 from . import vambtools
 from . import parsebam

--- a/vamb/parsebam.py
+++ b/vamb/parsebam.py
@@ -164,7 +164,7 @@ class Abundance:
         target_refhash: Optional[bytes],
         mask: _np.ndarray,
     ) -> A:
-        _os.mkdir(cache_directory)
+        _os.makedirs(cache_directory)
 
         chunks = [
             (i, min(len(paths), i + nthreads)) for i in range(0, len(paths), nthreads)


### PR DESCRIPTION
Temp files from PyCoverM are stored in out_dir/tmp/pycoverm, but the tmp directory was not created by the parsebam module. This led to a failure to make the pycoverm dir, crashing Vamb.

Fix issue #167