### PR TITLE
Refine zeromask check in latent normalization

### DIFF
--- a/vamb/cluster.py
+++ b/vamb/cluster.py
@@ -479,7 +479,8 @@ def _normalize(matrix: _Tensor, inplace: bool = False) -> _Tensor:
 
     # If any rows are kept all zeros, the distance function will return 0.5 to all points
     # inclusive itself, which can break the code in this module
-    zeromask = matrix.sum(dim=1) == 0
+    matrix[matrix < 0] = 0
+    zeromask = matrix.max(dim=1).values == 0
     matrix[zeromask] = 1 / matrix.shape[1]
     matrix /= matrix.norm(dim=1).reshape(-1, 1) * (2**0.5)
     return matrix


### PR DESCRIPTION
Previously, to check if every feature of a contig's latent representation was zero, Vamb checked if the mean was zero. This caused a small risk that a contig with nonzero latent space would happen to sum to zero. Now, instead check if the largest value is zero.