### PR TITLE
Bump Cython compat version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ version = {attr = "vamb.__version__"}
 readme = {file = "README.md"}
 
 [build-system]
-requires = ["setuptools ~= 63.0", "Cython ~= 0.29"]
+requires = ["setuptools ~= 63.0", "Cython ~= 0.29.5"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]


### PR DESCRIPTION
ABI changes in Python 3.11 is incompatible with Cython versions < 0.29.5. This may fix #176, or may not.