### PR TITLE
Remove sigma layer from the model

### DIFF
--- a/test/test_encode.py
+++ b/test/test_encode.py
@@ -180,8 +180,8 @@ class TestVAE(unittest.TestCase):
         di = torch.Tensor(rpkm_copy)
         ti = torch.Tensor(tnfs_copy)
         we = dl.dataset.tensors[2]
-        do, to, mu, lsigma = vae(di, ti)
-        start_loss = vae.calc_loss(di, do, ti, to, mu, lsigma, we)[0].data.item()
+        do, to, mu = vae(di, ti)
+        start_loss = vae.calc_loss(di, do, ti, to, mu, we)[0].data.item()
         iobuffer = io.StringIO()
 
         with tempfile.TemporaryFile() as file:
@@ -189,8 +189,8 @@ class TestVAE(unittest.TestCase):
             vae.trainmodel(
                 dl, nepochs=3, batchsteps=[1, 2], logfile=iobuffer, modelfile=file
             )
-            do, to, mu, lsigma = vae(di, ti)
-            end_loss = vae.calc_loss(di, do, ti, to, mu, lsigma, we)[0].data.item()
+            do, to, mu = vae(di, ti)
+            end_loss = vae.calc_loss(di, do, ti, to, mu, we)[0].data.item()
             self.assertLess(end_loss, start_loss)
 
             # Also test save/load


### PR DESCRIPTION
An old bug in Vamb constrained the value of logsigma to be positive due to a softplus operation on the logsigma. However, the optimal logsigma values for all VAEs are negative, which meant logsigma was essentially fixed to zero. Therefore, we can simply remove the sigma layer and directly substitute a zero.

A better long-term solution might be to properly add a sigma layer and fix the bug, but unfortunately, Vamb has been optimised around the bug for so long that this would be a bigger operation.