### PR TITLE
Create RefHasher type

### DIFF
--- a/test/test_parsebam.py
+++ b/test/test_parsebam.py
@@ -33,7 +33,7 @@ class TestParseBam(unittest.TestCase):
         # Change the refnames slighty
         cp.identifiers = cp.identifiers.copy()
         cp.identifiers[3] = cp.identifiers[3] + "w"
-        cp.refhash = vamb.vambtools.hash_refnames(cp.identifiers)
+        cp.refhash = vamb.vambtools.RefHasher.hash_refnames(cp.identifiers)
         with self.assertRaises(ValueError):
             vamb.parsebam.Abundance.from_files(
                 testtools.BAM_FILES, None, cp, True, 0.97, 4

--- a/test/test_vambtools.py
+++ b/test/test_vambtools.py
@@ -340,24 +340,33 @@ class TestInplaceMaskArray(unittest.TestCase):
 class TestHashRefNames(unittest.TestCase):
     def test_refhash(self):
         names = ["foo", "9", "eleven", "a"]
-        b1 = vamb.vambtools.hash_refnames(names)
+        b1 = vamb.vambtools.RefHasher.hash_refnames(names)
+
+        # Test that hashing them all at once is the same as hashing them one at a time
+        hasher = vamb.vambtools.RefHasher()
+        hasher.add_refname(names[0])
+        hasher.add_refname(names[1])
+        for j in names[2:]:
+            hasher.add_refname(j)
+        b7 = hasher.digest()
+
         names[1] = names[1] + "x"
-        b2 = vamb.vambtools.hash_refnames(names)
+        b2 = vamb.vambtools.RefHasher.hash_refnames(names)
         names[1] = names[1][:-1] + " \t"  # it strips whitespace off right end
-        b3 = vamb.vambtools.hash_refnames(names)
+        b3 = vamb.vambtools.RefHasher.hash_refnames(names)
         names = names[::-1]
-        b4 = vamb.vambtools.hash_refnames(names)
+        b4 = vamb.vambtools.RefHasher.hash_refnames(names)
+
         names = (i + "   " for i in names[::-1])
-        b5 = vamb.vambtools.hash_refnames(names)
-        b6 = vamb.vambtools.hash_refnames(names)  # now empty generator
-        b7 = vamb.vambtools.hash_refnames([])
+        b5 = vamb.vambtools.RefHasher.hash_refnames(names)
+        b6 = vamb.vambtools.RefHasher.hash_refnames(names)  # now empty generator
 
         self.assertNotEqual(b1, b2)
         self.assertEqual(b1, b3)
         self.assertNotEqual(b1, b4)
         self.assertEqual(b1, b5)
         self.assertNotEqual(b1, b6)
-        self.assertEqual(b6, b7)
+        self.assertEqual(b1, b7)
 
 
 class TestBinSplit(unittest.TestCase):

--- a/vamb/parsecontigs.py
+++ b/vamb/parsecontigs.py
@@ -55,7 +55,7 @@ class CompositionMetaData:
         self.lengths = lengths
         self.mask = mask
         self.minlength = minlength
-        self.refhash = _vambtools.hash_refnames(identifiers)
+        self.refhash = _vambtools.RefHasher.hash_refnames(identifiers)
 
     @property
     def nseqs(self) -> int:
@@ -73,7 +73,7 @@ class CompositionMetaData:
 
         self.identifiers = self.identifiers[mask]
         self.lengths = self.lengths[mask]
-        self.refhash = _vambtools.hash_refnames(self.identifiers)
+        self.refhash = _vambtools.RefHasher.hash_refnames(self.identifiers)
 
     def filter_min_length(self, length: int):
         "Set or reset minlength of this object"

--- a/workflow_avamb/avamb.snake.conda.smk
+++ b/workflow_avamb/avamb.snake.conda.smk
@@ -1,7 +1,6 @@
 import re
 import os
 import sys
-from vamb.vambtools import concatenate_fasta, hash_refnames
 import numpy as np
 SNAKEDIR = os.path.dirname(workflow.snakefile)
 

--- a/workflow_avamb/src/abundances_mask.py
+++ b/workflow_avamb/src/abundances_mask.py
@@ -1,6 +1,6 @@
 import numpy as np
 import argparse
-from vamb.vambtools import hash_refnames
+from vamb.vambtools import RefHasher
 from pathlib import Path
 
 
@@ -24,7 +24,7 @@ def abundances_mask(headers: Path, mask_refhash: Path, min_contig_size: int):
     np.savez_compressed(
         mask_refhash,
         mask=np.array(mask, dtype=bool),
-        refhash=hash_refnames(identifiers),
+        refhash=RefHasher.hash_refnames(identifiers),
     )
 
 


### PR DESCRIPTION
When only the Abundance type used refhashing, we could get away with it only being a simple function. However, now that I want marker gene prediction to also use refhashing, the existing implementation did not work, and I would need to have two differing implementation that absolutely needed to give the same result.

Instead, make a RefHasher type such that the invariants are stored in one place, and also generalize the error message improvement from commit 37277e2.