### PR TITLE
Rehaul and tweak clustering

### DIFF
--- a/test/test_cluster.py
+++ b/test/test_cluster.py
@@ -9,25 +9,30 @@ import vamb
 
 class TestClusterer(unittest.TestCase):
     data = np.random.random((1024, 40)).astype(np.float32)
+    lens = np.random.randint(500, 1000, size=1024)
 
     def test_bad_params(self):
         with self.assertRaises(ValueError):
-            vamb.cluster.ClusterGenerator(self.data.astype(np.float64))
+            vamb.cluster.ClusterGenerator(self.data.astype(np.float64), self.lens)
 
         with self.assertRaises(ValueError):
-            vamb.cluster.ClusterGenerator(self.data, maxsteps=0)
+            vamb.cluster.ClusterGenerator(self.data, self.lens, maxsteps=0)
 
         with self.assertRaises(ValueError):
-            vamb.cluster.ClusterGenerator(self.data, windowsize=0)
+            vamb.cluster.ClusterGenerator(self.data, self.lens, windowsize=0)
 
         with self.assertRaises(ValueError):
-            vamb.cluster.ClusterGenerator(self.data, minsuccesses=0)
+            vamb.cluster.ClusterGenerator(self.data, self.lens, minsuccesses=0)
 
         with self.assertRaises(ValueError):
-            vamb.cluster.ClusterGenerator(self.data, minsuccesses=5, windowsize=4)
+            vamb.cluster.ClusterGenerator(
+                self.data, self.lens, minsuccesses=5, windowsize=4
+            )
 
         with self.assertRaises(ValueError):
-            vamb.cluster.ClusterGenerator(np.random.random((0, 40)))
+            vamb.cluster.ClusterGenerator(
+                np.random.random((0, 40)), np.array([], dtype=int)
+            )
 
     # In the code, in __init__ of the cluster generator, the input matrix
     # is shuffled, and an index array is permuted to keep track of which
@@ -43,7 +48,7 @@ class TestClusterer(unittest.TestCase):
         self.assertTrue(np.all(cplike == cp))
 
     def test_basics(self):
-        clstr = vamb.cluster.ClusterGenerator(self.data)
+        clstr = vamb.cluster.ClusterGenerator(self.data, self.lens)
         self.assertIs(clstr, iter(clstr))
 
         x = next(clstr)
@@ -63,9 +68,9 @@ class TestClusterer(unittest.TestCase):
 
     def test_detruction(self):
         copy = self.data.copy()
-        clstr = vamb.cluster.ClusterGenerator(self.data)
+        clstr = vamb.cluster.ClusterGenerator(self.data, self.lens)
         self.assertTrue(np.any(np.abs(self.data - clstr.matrix.numpy()) > 0.001))
-        clstr = vamb.cluster.ClusterGenerator(copy, destroy=True)
+        clstr = vamb.cluster.ClusterGenerator(copy, self.lens, destroy=True)
         self.assertTrue(np.all(np.abs(copy - clstr.matrix.numpy()) < 1e-6))
         self.assertTrue(np.any(np.abs(self.data - clstr.matrix.numpy()) > 0.001))
 
@@ -80,21 +85,21 @@ class TestClusterer(unittest.TestCase):
 
     def test_normalization(self):
         hash_before = md5(self.data.data.tobytes()).digest().hex()
-        vamb.cluster.ClusterGenerator(self.data)
+        vamb.cluster.ClusterGenerator(self.data, self.lens)
         self.assertEqual(hash_before, md5(self.data.data.tobytes()).digest().hex())
         cp = self.data.copy()
-        vamb.cluster.ClusterGenerator(cp, destroy=True)
+        vamb.cluster.ClusterGenerator(cp, self.lens, destroy=True)
         hash_after = md5(cp.data.tobytes()).digest().hex()
         self.assertNotEqual(hash_before, hash_after)
 
         # Rows are permuted by the clusterer. We use xor to check the rows
         # are still essentially the same.
         before_xor = self.xor_rows_hash(cp)
-        vamb.cluster.ClusterGenerator(cp, destroy=True, normalized=True)
+        vamb.cluster.ClusterGenerator(cp, self.lens, destroy=True, normalized=True)
         self.assertEqual(before_xor, self.xor_rows_hash(cp))
 
     def test_cluster(self):
-        x = next(vamb.cluster.ClusterGenerator(self.data))
+        x = next(vamb.cluster.ClusterGenerator(self.data, self.lens))
         self.assertIsInstance(x.members, np.ndarray)
         med, st = x.as_tuple()
         self.assertIsInstance(st, set)
@@ -105,19 +110,20 @@ class TestClusterer(unittest.TestCase):
 class TestPairs(unittest.TestCase):
     n_samples = 1024
     data = np.random.random((n_samples, 40)).astype(np.float32)
+    lens = np.random.randint(500, 1000, size=1024)
 
     @staticmethod
     def randstring(len):
         return "".join(random.choices(string.ascii_letters, k=len))
 
     def test_too_few_names(self):
-        clstr = vamb.cluster.ClusterGenerator(self.data)
+        clstr = vamb.cluster.ClusterGenerator(self.data, self.lens)
         nameset = {self.randstring(10) for i in range(len(self.data) - 1)}
         with self.assertRaises(ValueError):
             list(vamb.cluster.pairs(clstr, list(nameset)))
 
     def test_pairs(self):
-        clstr = vamb.cluster.ClusterGenerator(self.data)
+        clstr = vamb.cluster.ClusterGenerator(self.data, self.lens)
         nameset = {self.randstring(10) for i in range(len(self.data))}
         pairs = list(vamb.cluster.pairs(clstr, list(nameset)))
 

--- a/vamb/cluster.py
+++ b/vamb/cluster.py
@@ -14,7 +14,7 @@ from collections import deque as _deque
 from math import ceil as _ceil
 from torch.functional import Tensor as _Tensor
 import vamb.vambtools as _vambtools
-from typing import Optional
+from typing import TypeVar, Union, cast
 from collections.abc import Sequence, Iterable
 
 _DEFAULT_RADIUS = 0.06
@@ -23,6 +23,24 @@ _MEDOID_RADIUS = 0.05
 
 _DELTA_X = 0.005
 _XMAX = 0.3
+
+Cl = TypeVar("Cl", bound="Cluster")
+
+
+class Loner:
+    __slots__ = []
+    pass
+
+
+class NoThreshold:
+    __slots__ = []
+    pass
+
+
+class Default:
+    __slots__ = []
+    pass
+
 
 # This is the PDF of normal with µ=0, s=0.01 from -0.075 to 0.075 with intervals
 # of DELTA_X, for a total of 31 values. We multiply by _DELTA_X so the density
@@ -136,26 +154,55 @@ class ClusterGenerator:
     """
 
     __slots__ = [
+        # Maximum number of futile steps taken in the wander_medoid function until it gives up
+        # and emits the currently best medoid as the medoid
         "maxsteps",
+        # Minimum number of successul clusters emitted of the last `attempts`, lest the
+        # peak_valley_ratio be increased to prevent an infinite loop
         "minsuccesses",
+        # Whether this clusterer runs on GPU
         "cuda",
+        # Random number generator, currently used in wander_medoid function
         "rng",
+        # Actual data to be clustered
         "matrix",
+        # Lengths of input contigs
+        "lengths",
+        # This are the original indices of the rows of the matrix. Initially this is just 1..len(matrix),
+        # but if not on GPU, we delete used rows of the matrix (and indices) to speed up subsequent computations.
+        # Then, we can obtain the original row index by looking up in this array
         "indices",
-        "seed",
-        "nclusters",
+        # Original indices are scored from most promising as seeds to worse, and ordered in the `order` array.
+        # The best contig indices are first.
+        "order",
+        # The integer index in `order` which the clusterer on next iteration will try to use as medoid
+        "order_index",
+        "n_emitted_clusters",
+        "n_remaining_points",
+        # A float value which determines how strictly the clusterer rejects potential clusters.
+        # The lower, the stricter. We increase this adaptively to avoid clustering for ever
         "peak_valley_ratio",
+        # A deque to store whether the last N candicate clusters were rejected. See `minsuccesses`
         "attempts",
+        # An integer storing the number of True values in `attempts` to avoid looping over it
         "successes",
+        # A buffer in which a histrogram of distances from the current medoid is stored.
+        # Is overwritten on each iteration, we just keep it here to avoid allocations.
         "histogram",
+        "histogram_edges",
+        # This bool array is False if the contig at the given index has been emitted in a previous iteration.
+        # When matrix is on CPU, rows in this array (and the data matrix) is continuously deleted, and we use
+        # this array to keep track of which rows to delete each iteration.
+        # On GPU, deleting rows is not feasable because that requires us to copy the matrix from and to the GPU,
+        # so we instead use this array to mask away any point emitted in an earlier iteration.
         "kept_mask",
     ]
 
     def __repr__(self) -> str:
-        return f"ClusterGenerator({len(self.matrix)} points, {self.nclusters} clusters)"
+        return f"ClusterGenerator({len(self.matrix)} points, {self.n_emitted_clusters} clusters)"
 
     def __str__(self) -> str:
-        return f"""ClusterGenerator({len(self.matrix)} points, {self.nclusters} clusters)
+        return f"""ClusterGenerator({len(self.matrix)} points, {self.n_emitted_clusters} clusters)
   CUDA:         {self.cuda}
   maxsteps:     {self.maxsteps}
   minsuccesses: {self.minsuccesses}
@@ -164,7 +211,12 @@ class ClusterGenerator:
 """
 
     def _check_params(
-        self, matrix: _np.ndarray, maxsteps: int, windowsize: int, minsuccesses: int
+        self,
+        matrix: _np.ndarray,
+        lengths: _np.ndarray,
+        maxsteps: int,
+        windowsize: int,
+        minsuccesses: int,
     ) -> None:
         """Checks matrix, and maxsteps."""
 
@@ -185,6 +237,9 @@ class ClusterGenerator:
         if len(matrix) < 1:
             raise ValueError("Matrix must have at least 1 observation.")
 
+        if len(lengths) != len(matrix):
+            raise ValueError("N sequences in lengths and matrix do not match")
+
     def _init_histogram_kept_mask(self, N: int) -> tuple[_Tensor, _Tensor]:
         "N is number of contigs"
 
@@ -200,25 +255,26 @@ class ClusterGenerator:
     def __init__(
         self,
         matrix: _np.ndarray,
+        lengths: _np.ndarray,
         maxsteps: int = 25,
-        windowsize: int = 200,
-        minsuccesses: int = 20,
+        windowsize: int = 300,
+        minsuccesses: int = 15,
         destroy: bool = False,
         normalized: bool = False,
         cuda: bool = False,
-        seed: int = 0,
+        rng_seed: int = 0,
     ):
-        self._check_params(matrix, maxsteps, windowsize, minsuccesses)
+        self._check_params(
+            matrix,
+            lengths,
+            maxsteps,
+            windowsize,
+            minsuccesses,
+        )
         if not destroy:
             matrix = matrix.copy()
 
-        # Shuffle matrix in unison to prevent seed sampling bias. Indices keeps
-        # track of which points are which.
-        _np.random.Generator(_np.random.PCG64(seed)).shuffle(matrix)
-        indices = _np.random.Generator(_np.random.PCG64(seed)).permutation(len(matrix))
-        indices = _torch.from_numpy(indices)
         torch_matrix = _torch.from_numpy(matrix)
-
         if not normalized:
             _normalize(torch_matrix, inplace=True)
 
@@ -229,20 +285,24 @@ class ClusterGenerator:
         self.maxsteps: int = maxsteps
         self.minsuccesses: int = minsuccesses
         self.cuda: bool = cuda
-        self.rng: _random.Random = _random.Random(seed)
+        self.rng: _random.Random = _random.Random(rng_seed)
 
         self.matrix = torch_matrix
         # This refers to the indices of the original matrix. As we remove points, these
         # indices do not correspond to merely range(len(matrix)) anymore.
-        self.indices = indices
-        self.seed = -1
-        self.nclusters = 0
+        self.indices = _torch.arange(len(matrix))
+        self.order = _np.argsort(lengths)[::-1]
+        self.order_index = 0
+        self.lengths = _torch.Tensor(lengths)
+        self.n_emitted_clusters = 0
+        self.n_remaining_points = len(torch_matrix)
         self.peak_valley_ratio = 0.1
         self.attempts: _deque[bool] = _deque(maxlen=windowsize)
         self.successes = 0
 
-        histogram, kept_mask = self._init_histogram_kept_mask(len(indices))
+        histogram, kept_mask = self._init_histogram_kept_mask(len(self.indices))
         self.histogram = histogram
+        self.histogram_edges = _torch.linspace(0.0, _XMAX, round(_XMAX / _DELTA_X) + 1)
         self.kept_mask = kept_mask
 
     # It's an iterator itself
@@ -250,16 +310,12 @@ class ClusterGenerator:
         return self
 
     def __next__(self) -> Cluster:
-        # Stop criterion. For CUDA, inplace masking the array is too slow, so the matrix is
-        # unchanged. On CPU, we continually modify the matrix by removing rows.
-        if self.cuda:
-            if not _torch.any(self.kept_mask).item():
-                raise StopIteration
-        elif len(self.matrix) == 0:
+        if self.n_remaining_points == 0:
             raise StopIteration
 
-        cluster, _, points = self._findcluster()
-        self.nclusters += 1
+        cluster, _, points = self.find_cluster()
+        self.n_emitted_clusters += 1
+        self.n_remaining_points -= len(points)
 
         for point in points:
             self.kept_mask[point] = 0
@@ -267,186 +323,292 @@ class ClusterGenerator:
         # Remove all points that's been clustered away. Is slow it itself, but speeds up
         # distance calculation by having fewer points. Worth it on CPU, not on GPU
         if not self.cuda:
-            _vambtools.torch_inplace_maskarray(self.matrix, self.kept_mask)
-            # no need to inplace mask small array
-            self.indices = self.indices[self.kept_mask]
-            self.kept_mask.resize_(len(self.matrix))
-            self.kept_mask[:] = 1
+            self.pack()
 
         return cluster
 
-    def _findcluster(self) -> tuple[Cluster, int, _Tensor]:
-        """Finds a cluster to output."""
-        threshold, success, medoid = None, None, -1
+    def pack(self):
+        "Remove all used points from the matrix and indices, and reset kept_mask."
+        if self.cuda:
+            self.matrix = _vambtools.torch_inplace_maskarray(
+                self.matrix.cpu(), self.kept_mask
+            ).cuda()
+        else:
+            _vambtools.torch_inplace_maskarray(self.matrix, self.kept_mask)
 
-        # Keep looping until we find a cluster
-        distances = None
-        while threshold is None:
-            # If on GPU, we need to take next seed which has not already been clusted out.
-            # if not, clustered points have been removed, so we can just take next seed
-            if self.cuda:
-                self.seed = (self.seed + 1) % len(self.matrix)
-                while not self.kept_mask[self.seed]:
-                    self.seed = (self.seed + 1) % len(self.matrix)
-            else:
-                self.seed = (self.seed + 1) % len(self.matrix)
+        self.indices = self.indices[self.kept_mask]
+        self.lengths = self.lengths[self.kept_mask]
+        self.kept_mask.resize_(len(self.matrix))
+        self.kept_mask[:] = 1
 
-            medoid, distances = _wander_medoid(
+    def pack_order(self):
+        "Remove all used points from self.order"
+        self.order = self.order[self.order > -1]
+        assert len(self.order) > 0
+
+    def get_next_seed(self) -> int:
+        "Get the next seed index for a new medoid search"
+        n_original_contigs = len(self.order)
+        i = self.order_index - 1  # we increment by 1 in beginning of loop
+        while True:
+            # Get the order: That's the original index of the contig.
+            i = (i + 1) % n_original_contigs
+
+            # When we loop back to the first index after having passed over all indices before,
+            # we potentially have many used up -1 values to skip, so we remove these
+            # Since the clustering algorithm may loop over self.order many times, we can potentially
+            # save time.
+            # When running on GPU, we also take this (rare-ish) chance to pack the on-GPU matrix.
+            # This speeds up future distance calculation by making the matrix smaller, but requires
+            # moving the matrix from and to GPU, so is slow.
+            # Doing it here, which we assume is relatively rarely may be a good compromise
+            if i == 0 and self.n_emitted_clusters > 0:
+                if self.cuda:
+                    self.pack()
+                self.pack_order()
+                n_original_contigs = len(self.order)
+
+            order = self.order[i]
+            # -1 signify an index which has previously been used up
+            if order == -1:
+                continue
+
+            # Find the new index of this old index
+            new_index = cast(int, _torch.searchsorted(self.indices, order).item())
+            # It's possible the seed contig `order` is part of a previously emitted cluster,
+            # in which case it's not to be found in self.indices. In that case, mark the order
+            # as -1, and go to the next one
+            if (
+                new_index >= len(self.indices)
+                or self.indices[new_index].item() != order
+            ):
+                self.order[i] = -1
+                continue
+
+            self.order_index = (
+                i + 1
+            )  # Move to next index for the next time this is called
+            return new_index
+
+    def update_successes(self, success: bool):
+        """Keeps track of how many clusters have been rejected (False) and accepted (True).
+        When sufficiently many False has been seen, the peak_valley_ratio is bumped, which relaxes
+        the criteria for rejection.
+        This prevents the clusterer from getting stuck in an infinite loop.
+        """
+
+        # Keep accurately track of successes if we exceed maxlen
+        if len(self.attempts) == self.attempts.maxlen:
+            self.successes -= self.attempts.popleft()
+
+        # Add the current success to count
+        self.successes += success
+        self.attempts.append(success)
+
+        # If less than minsuccesses of the last maxlen attempts were successful,
+        # we relax the clustering criteria and reset counting successes.
+        if (
+            len(self.attempts) == self.attempts.maxlen
+            and self.successes < self.minsuccesses
+        ):
+            self.peak_valley_ratio += 0.1
+            self.attempts.clear()
+            self.successes = 0
+
+            # After relaxing criteria, start over from the best candidate
+            # seed contigs which may have been skipped the first time around
+            self.order_index = 0
+
+    def wander_medoid(self, seed) -> tuple[int, _Tensor]:
+        """Keeps sampling new points within the cluster until it has sampled
+        max_attempts without getting a new set of cluster with lower average
+        distance"""
+
+        medoid = seed
+        cluster, distances, local_density = _sample_medoid(
+            self.matrix, self.lengths, self.kept_mask, seed, _MEDOID_RADIUS, self.cuda
+        )
+        candidates = self.rng.choices(
+            cluster.tolist(), k=min(len(cluster), self.maxsteps)
+        )
+        self.rng.shuffle(candidates)
+        i = 0
+
+        while i < len(candidates):
+            sampled_medoid = candidates[i]
+            sampling = _sample_medoid(
                 self.matrix,
+                self.lengths,
                 self.kept_mask,
-                self.seed,
-                self.maxsteps,
-                self.rng,
+                sampled_medoid,
+                _MEDOID_RADIUS,
                 self.cuda,
             )
+            sample_cluster, sample_distances, sample_density = sampling
 
-            # We need to make a histogram of only the unclustered distances - when run on GPU
-            # these have not been removed and we must use the kept_mask
-            if self.cuda:
-                _torch.histc(
-                    distances[self.kept_mask],
-                    len(self.histogram),
-                    0,
-                    _XMAX,
-                    out=self.histogram,
+            # If the mean distance of inner points of the sample is lower,
+            # we move the medoid and start over
+            if sample_density > local_density:
+                medoid = sampled_medoid
+                cluster = sample_cluster
+                distances = sample_distances
+                local_density = sample_density
+                candidates = self.rng.choices(
+                    cluster.tolist(), k=min(len(cluster), self.maxsteps)
                 )
+                self.rng.shuffle(candidates)
+                i = 0
             else:
-                _torch.histc(
-                    distances, len(self.histogram), 0, _XMAX, out=self.histogram
-                )
-            self.histogram[0] -= 1  # Remove distance to self
+                i += 1
 
-            threshold, success = _find_threshold(
-                self.histogram, self.peak_valley_ratio, self.cuda
-            )
+        return (medoid, distances)
 
-            # If success is not None, either threshold detection failed or succeded.
-            if success is not None:
-                # Keep accurately track of successes if we exceed maxlen
-                if len(self.attempts) == self.attempts.maxlen:
-                    self.successes -= self.attempts.popleft()
+    def find_threshold(
+        self, distances: _Tensor
+    ) -> Union[Loner, NoThreshold, Default, float]:
+        # If the point is a loner, immediately return a threshold in where only
+        # that point is contained.
+        # TODO: Avoid this dual pass in this critical function for performance? How...?
+        if _torch.count_nonzero(distances < 0.05) == 1:
+            return Loner()
 
-                # Add the current success to count
-                self.successes += success
-                self.attempts.append(success)
-
-                # If less than minsuccesses of the last maxlen attempts were successful,
-                # we relax the clustering criteria and reset counting successes.
-                if (
-                    len(self.attempts) == self.attempts.maxlen
-                    and self.successes < self.minsuccesses
-                ):
-                    self.peak_valley_ratio += 0.1
-                    self.attempts.clear()
-                    self.successes = 0
-
-        # These are the points of the final cluster AFTER establishing the threshold used
-        assert isinstance(distances, _Tensor)
-        points = _smaller_indices(distances, self.kept_mask, threshold, self.cuda)
-        isdefault = (
-            success is None
-            and threshold == _DEFAULT_RADIUS
-            and self.peak_valley_ratio > 0.55
+        # We need to make a histogram of only the unclustered distances - when run on GPU
+        # these have not been removed and we must use the kept_mask
+        if self.cuda:
+            picked_distances = distances[self.kept_mask]
+        else:
+            picked_distances = distances
+        _torch.histogram(
+            input=picked_distances,
+            bins=len(self.histogram),
+            range=(0.0, _XMAX),
+            out=((self.histogram, self.histogram_edges)),
+            weight=self.lengths,
         )
+        # TODO: Decide: Should we remove the self point? This might create an invalid initial peak.
+        # On the other hand, if it's large, the peak is valid...
 
-        cluster = Cluster(
-            int(self.indices[medoid].item()),  # type: ignore
-            self.seed,
-            self.indices[points].numpy(),
-            self.peak_valley_ratio,
-            threshold,
-            isdefault,
-            self.successes,
-            len(self.attempts),
-        )
-        return cluster, medoid, points
-
-
-def _calc_densities(
-    histogram: _Tensor, cuda: bool, pdf: _Tensor = _NORMALPDF
-) -> _Tensor:
-    """Given an array of histogram, smoothes the histogram."""
-    pdf_len = len(pdf)
-
-    if cuda:
-        histogram = histogram.cpu()
-
-    densities = _torch.zeros(len(histogram) + pdf_len - 1)
-    for i in range(len(densities) - pdf_len + 1):
-        densities[i : i + pdf_len] += pdf * histogram[i]
-
-    densities = densities[15:-15]
-
-    return densities
-
-
-def _find_threshold(
-    histogram: _Tensor, peak_valley_ratio: float, cuda: bool
-) -> tuple[Optional[float], Optional[bool]]:
-    """Find a threshold distance, where where is a dip in point density
-    that separates an initial peak in densities from the larger bulk around 0.5.
-    Returns (threshold, success), where succes is False if no threshold could
-    be found, True if a good threshold could be found, and None if the point is
-    alone, or the threshold has been used.
-    """
-    peak_density = 0
-    peak_over = False
-    minimum_x = None
-    density_at_minimum = None
-    threshold = None
-    success = False
-    delta_x = _XMAX / len(histogram)
-
-    # If the point is a loner, immediately return a threshold in where only
-    # that point is contained.
-    if histogram[:10].sum().item() == 0:
-        return 0.025, None
-
-    densities = _calc_densities(histogram, cuda)
-
-    # Else we analyze the point densities to find the valley
-    x = 0
-    density_at_minimum = 0.0
-    for density in densities:
-        # Define the first "peak" in point density. That's simply the max until
-        # the peak is defined as being over.
-        if not peak_over and density > peak_density:
-            # Do not accept first peak to be after x = 0.1
-            if x > 0.1:
-                break
-            peak_density = density
-
-        # Peak is over when density drops below 60% of peak density
-        if not peak_over and density < 0.6 * peak_density:
-            peak_over = True
-            density_at_minimum = density
-
-        # If another peak is detected, we stop
-        if peak_over and density > 1.5 * density_at_minimum:
-            break
-
-        # Now find the minimum after the peak
-        if peak_over and density < density_at_minimum:
-            minimum_x, density_at_minimum = x, density
-
-            # If this minimum is below ratio * peak, it's accepted as threshold
-            if density < peak_valley_ratio * peak_density:
-                threshold = minimum_x
-                success = True
-
-        x += delta_x
-
-    # Don't allow a threshold too high - this is relaxed with p_v_ratio
-    if threshold is not None and threshold > 0.2 + peak_valley_ratio:
+        # When the peak_valley_ratio is too high, we need to return something to not get caught
+        # in an infinite loop.
+        must_return_points = self.peak_valley_ratio > 0.55
+        peak_density = 0.0
+        peak_over = False
+        minimum_x = 0.0
         threshold = None
-        success = False
+        delta_x = _XMAX / len(self.histogram)
+        pdf_len = len(_NORMALPDF)
 
-    # If ratio has been set to 0.6, we do not accept returning no threshold.
-    if threshold is None and peak_valley_ratio > 0.55:
-        threshold = _DEFAULT_RADIUS
-        success = None
+        if self.cuda:
+            histogram = self.histogram.cpu()
+        else:
+            histogram = self.histogram
 
-    return threshold, success
+        # This smoothes out the histogram, so we can more reliably detect peaks
+        # and valleys.
+        densities = _torch.zeros(len(histogram) + pdf_len - 1)
+        for i in range(len(densities) - pdf_len + 1):
+            densities[i : i + pdf_len] += _NORMALPDF * histogram[i]
+        densities = densities[15:-15]
+
+        # Analyze the point densities to find the valley
+        x = 0
+        density_at_minimum = 0.0
+        for density in densities:
+            # Define the first "peak" in point density. That's simply the max until
+            # the peak is defined as being over.
+            if not peak_over and density > peak_density:
+                # Do not accept first peak to be after x = 0.1
+                if x > 0.1:
+                    return Default() if must_return_points else NoThreshold()
+                peak_density = density
+
+            # Peak is over when density drops below 60% of peak density
+            if not peak_over and density < 0.6 * peak_density:
+                peak_over = True
+                density_at_minimum = density
+
+            # If another peak is detected, we stop
+            if peak_over and density > 1.5 * density_at_minimum:
+                break
+
+            # Now find the minimum after the peak
+            if peak_over and density < density_at_minimum:
+                minimum_x, density_at_minimum = x, density
+
+                # If this minimum is below ratio * peak, it's accepted as threshold
+                if density < self.peak_valley_ratio * peak_density:
+                    threshold = minimum_x
+
+            x += delta_x
+
+        # If we have not detected a threshold, we can't return one.
+        if threshold is None:
+            return Default() if must_return_points else NoThreshold()
+        # Else, we check whether the threshold is too high. If not, we return it.
+        else:
+            if threshold > 0.2 + self.peak_valley_ratio:
+                return Default() if must_return_points else NoThreshold()
+            else:
+                return threshold
+
+    def find_cluster(self) -> tuple[Cluster, int, _Tensor]:
+        while True:
+            seed = self.get_next_seed()
+            medoid, distances = self.wander_medoid(seed)
+            threshold = self.find_threshold(distances)
+            if isinstance(threshold, Loner):
+                cluster = Cluster(
+                    int(self.indices[medoid].item()),  # type: ignore
+                    seed,
+                    _np.array([self.indices[medoid].item()]),
+                    self.peak_valley_ratio,
+                    _DEFAULT_RADIUS,
+                    False,
+                    self.successes,
+                    len(self.attempts),
+                )
+                points = _torch.IntTensor([medoid])
+                return (cluster, medoid, points)
+
+            elif isinstance(threshold, Default):
+                points = _smaller_indices(
+                    distances, self.kept_mask, _DEFAULT_RADIUS, self.cuda
+                )
+                cluster = Cluster(
+                    int(self.indices[medoid].item()),  # type: ignore
+                    seed,
+                    self.indices[points].numpy(),
+                    self.peak_valley_ratio,
+                    _DEFAULT_RADIUS,
+                    True,
+                    self.successes,
+                    len(self.attempts),
+                )
+                return (cluster, medoid, points)
+
+            elif isinstance(threshold, NoThreshold):
+                self.update_successes(False)
+
+            elif isinstance(threshold, float):
+                points = _smaller_indices(
+                    distances, self.kept_mask, threshold, self.cuda
+                )
+                cluster = Cluster(
+                    int(self.indices[medoid].item()),  # type: ignore
+                    seed,
+                    self.indices[points].numpy(),
+                    self.peak_valley_ratio,
+                    threshold,
+                    False,
+                    self.successes,
+                    len(self.attempts),
+                )
+                if self.peak_valley_ratio < 0.55:
+                    self.update_successes(True)
+                return (cluster, medoid, points)
+
+            else:  # No more types
+                assert False
 
 
 def _smaller_indices(
@@ -493,7 +655,12 @@ def _calc_distances(matrix: _Tensor, index: int) -> _Tensor:
 
 
 def _sample_medoid(
-    matrix: _Tensor, kept_mask: _Tensor, medoid: int, threshold: float, cuda: bool
+    matrix: _Tensor,
+    lengths: _Tensor,
+    kept_mask: _Tensor,
+    medoid: int,
+    threshold: float,
+    cuda: bool,
 ) -> tuple[_Tensor, _Tensor, float]:
     """Returns:
     - A vector of indices to points within threshold
@@ -503,61 +670,8 @@ def _sample_medoid(
 
     distances = _calc_distances(matrix, medoid)
     cluster = _smaller_indices(distances, kept_mask, threshold, cuda)
-
-    if len(cluster) == 1:
-        average_distance = 0.0
-    else:
-        average_distance = distances[cluster].sum().item() / (len(cluster) - 1)
-
-    return cluster, distances, average_distance
-
-
-def _wander_medoid(
-    matrix: _Tensor,
-    kept_mask: _Tensor,
-    medoid: int,
-    max_attempts: int,
-    rng: _random.Random,
-    cuda: bool,
-) -> tuple[int, _Tensor]:
-    """Keeps sampling new points within the cluster until it has sampled
-    max_attempts without getting a new set of cluster with lower average
-    distance"""
-
-    futile_attempts = 0
-    tried = {medoid}  # keep track of already-tried medoids
-    cluster, distances, average_distance = _sample_medoid(
-        matrix, kept_mask, medoid, _MEDOID_RADIUS, cuda
-    )
-
-    while len(cluster) - len(tried) > 0 and futile_attempts < max_attempts:
-        sampled_medoid = int(cluster[rng.randrange(len(cluster))].item())
-
-        # Prevent sampling same medoid multiple times.
-        while sampled_medoid in tried:
-            sampled_medoid = int(cluster[rng.randrange(len(cluster))].item())
-
-        tried.add(sampled_medoid)
-
-        sampling = _sample_medoid(
-            matrix, kept_mask, sampled_medoid, _MEDOID_RADIUS, cuda
-        )
-        sample_cluster, sample_distances, sample_avg = sampling
-
-        # If the mean distance of inner points of the sample is lower,
-        # we move the medoid and reset the futile_attempts count
-        if sample_avg < average_distance:
-            medoid = sampled_medoid
-            cluster = sample_cluster
-            average_distance = sample_avg
-            futile_attempts = 0
-            tried = {medoid}
-            distances = sample_distances
-
-        else:
-            futile_attempts += 1
-
-    return medoid, distances
+    local_density = (lengths[cluster] * (threshold - distances[cluster])).sum().item()
+    return cluster, distances, local_density
 
 
 def pairs(


### PR DESCRIPTION
This commit is a squashed version of several commits that can be found on the exp_cluster branch, and which has been tested individually. It contains the following changes:

Seed ordering

Before, the order in which seed contigs were picked was randomized, in order to prevent bias arising from the order of the sequences in the FASTA files. Now, we pick the seeds in a precomputed order, here the contig length. The idea is that the contigs which we are most confident should belong to a good cluster gets "first pick" during clustering to see if they can form proper clusters.

Length weighting

When computing the distance histogram from which the threshold is found, contigs are now weighed by their length. This should make it more likely to correctly detect clusters composed of a small number of large contigs. In testing, this improves binning result, and the distance histograms become clearer and more well-shaped.

Simplified medoid search

Before, the medoid should have the lowest mean distance to each contig within a small radius. Now, since we take length into accounts when finding the threshold, instead choose the medoid that has the highest "local density". This is computed as sum(length * (R - distance)) where R is a small contant, for each contig where distance <= R.
Also, the random sampling of medoids is now simpler and should be more efficient

Various refactorings and tweaks

* Update the hyperparameters windowsize and minsuccesses to make Vamb the cluster selection criteria stricter
* Implement a pack function which deleted used points in the matrix and associated vectors. This enables better control of when the matrix is packed, which should make clustering faster
* When the peak valley ratio is raised, start over from the highest ordered seed. This makes sure the highest ordered seeds are attempted multiple times.
* Misc refactoring