### PR TITLE
parsebam.py - added optional arguments to run_pycoverm

### DIFF
--- a/vamb/parsebam.py
+++ b/vamb/parsebam.py
@@ -194,9 +194,9 @@ class Abundance:
     def run_pycoverm(
         paths: list[Path],
         minid: float,
-        target_refhash: Optional[bytes],
-        target_identifiers: Optional[Iterable[str]],
         mask: _np.ndarray,
+        target_refhash: Optional[bytes] = None,
+        target_identifiers: Optional[Iterable[str]] = None,
     ) -> tuple[_np.ndarray, bytes]:
         (headers, coverage) = pycoverm.get_coverages_from_bam(
             [str(p) for p in paths],


### PR DESCRIPTION
Added "None" to optional arguments in parsebam.Abundance.run_pycoverm. 

In the logs originating from the bam_abundance rule in the avamb workflow I got the following error:

"vamb/workflow_avamb/src/write_abundances.py", line 30, in <module>
    write_abundances(opt.msk, opt.b, opt.min_id, opt.out)
  File "vamb/workflow_avamb/src/write_abundances.py", line 15, in write_abundances
    (abundance, _) = vamb.parsebam.Abundance.run_pycoverm(
TypeError: run_pycoverm() missing 1 required positional argument: 'target_identifiers'

After adding the default values for the optional arguments and repositioning them, the snakemake pipeline continued.


