### PR TITLE
Fix GPU clustering

### DIFF
--- a/vamb/cluster.py
+++ b/vamb/cluster.py
@@ -384,6 +384,7 @@ class ClusterGenerator:
             if (
                 new_index >= len(self.indices)
                 or self.indices[new_index].item() != order
+                or (self.cuda and not self.kept_mask[new_index].item())
             ):
                 self.order[i] = -1
                 continue

--- a/vamb/cluster.py
+++ b/vamb/cluster.py
@@ -482,7 +482,7 @@ class ClusterGenerator:
             picked_distances = distances[below_xmax].cpu()
             picked_lengths = self.lengths[below_xmax].cpu()
         else:
-            below_xmax = (distances <= _XMAX)
+            below_xmax = distances <= _XMAX
             picked_distances = distances[below_xmax]
             picked_lengths = self.lengths[below_xmax]
 


### PR DESCRIPTION
Commit #6554009 messed up clustering on the GPU, which requires that for all array ops, both arrays are on the same device. Fix this.

NOTE: Marking as draft because currently, the `.cpu()` calls before `torch.histogram` destroys performance, so this will have to be fixed.