### PR TITLE
Log-transform absolute abundances

### DIFF
--- a/vamb/encode.py
+++ b/vamb/encode.py
@@ -125,6 +125,7 @@ def make_dataloader(
     rpkm /= nonzero_total_abundance.reshape((-1, 1))
 
     # Normalize TNF and total abundance to make SSE loss work better
+    total_abundance = _np.log(total_abundance.clip(min=0.001))
     _vambtools.zscore(total_abundance, inplace=True)
     _vambtools.zscore(tnf, axis=0, inplace=True)
     total_abundance.shape = (len(total_abundance), 1)


### PR DESCRIPTION
Since abdundances are natually exponentially distributed, it makes sense to log scale them.
I've clamped abundances to a minimum of to 10^-4. I think that is conservative, since I believe it's not realistic that we can meaningfully distinguish a seq with an abundance of 1e-4 from one with zero.