### PR TITLE
Trim 25% top and bottom positions when computing abundance

### DIFF
--- a/vamb/parsebam.py
+++ b/vamb/parsebam.py
@@ -202,9 +202,9 @@ class Abundance:
             [str(p) for p in paths],
             threads=len(paths),
             min_identity=minid,
-            # Note: pycoverm's trim_upper=0.1 is same as CoverM trim-upper 90.
-            trim_upper=0.1,
-            trim_lower=0.1,
+            # Note: pycoverm's trim_upper=0.250 is same as CoverM trim-upper 75.
+            trim_upper=0.25,
+            trim_lower=0.25,
         )
 
         assert coverage.shape == (len(headers), len(paths))


### PR DESCRIPTION
Vamb computes abundance for each sequence the following way: The depth at each position is computed. Then, the top and bottom 10% positions are thrown away, and the mean depth of the rest is computed. The outliers are discarded because it's believed that sequences can contain conserved or poorly assembled regions which may mess with the mapping, by either recruiting too many reads (from related sequences) or too few (as they either cannot map to poorly assembled regions, or are recruited to other sequences). This trimming moves the result closer to the median than the mean, making it more stable.

In this commit, trim more aggressively, as we have found that the observed depth varies more than we initially expected.