### PR TITLE
Bugfix: Correct number of elements in AAMB dataloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ cd vamb
 pip install -e .
 ```
 
+__note that the master branch is work-in-progress and is expected to have more bugs__
+
 ### Installing by compiling the Cython yourself
 
 If you can't/don't want to use pip/Conda, you can do it the hard way: Get the most recent versions of the Python packages `cython`, `numpy`, `torch` and `pycoverm`. Compile `src/_vambtools.pyx` then move the resulting binary to the inner of the two `vamb` directories. Check if it works by importing `vamb` in a Python session.

--- a/vamb/aamb_encode.py
+++ b/vamb/aamb_encode.py
@@ -264,7 +264,7 @@ class AAE(nn.Module):
             total_batches_inthis_epoch = len(data_loader)
             time_epoch_0 = time.time()
 
-            for depths_in, tnfs_in, _ in data_loader:  # weights currently unused here
+            for depths_in, tnfs_in, _, _ in data_loader:  # weights, abundances currently unused here
                 nrows, _ = depths_in.shape
 
                 # Adversarial ground truths
@@ -451,7 +451,7 @@ class AAE(nn.Module):
         clust_y_dict: dict[str, set[str]] = dict()
         Tensor = torch.cuda.FloatTensor if self.usecuda else torch.FloatTensor
         with torch.no_grad():
-            for depths_in, tnfs_in, _ in new_data_loader:
+            for depths_in, tnfs_in, _, _ in new_data_loader:
                 nrows, _ = depths_in.shape
                 if self.usecuda:
                     z_prior = torch.cuda.FloatTensor(nrows, self.ld).normal_()

--- a/vamb/aamb_encode.py
+++ b/vamb/aamb_encode.py
@@ -264,7 +264,8 @@ class AAE(nn.Module):
             total_batches_inthis_epoch = len(data_loader)
             time_epoch_0 = time.time()
 
-            for depths_in, tnfs_in, _, _ in data_loader:  # weights, abundances currently unused here
+            # weights, abundances currently unused here
+            for depths_in, tnfs_in, _, _ in data_loader:
                 nrows, _ = depths_in.shape
 
                 # Adversarial ground truths

--- a/workflow_avamb/README.md
+++ b/workflow_avamb/README.md
@@ -25,7 +25,9 @@ To run the workflow first install a Python3 version of [Miniconda](https://docs.
  mamba create -n avamb python=3.9.16
  mamba env update -n avamb --file vamb/workflow_avamb/envs/avamb.yaml
  conda activate avamb 
- cd vamb && pip install -e . && cd ..
+ cd vamb
+ git checkout v4.1.3 # check out chosen version
+ pip install -e . && cd ..
  # Install CheckM2 in checkm2 environment
  git clone https://github.com/chklovski/CheckM2.git 
  mamba create -n checkm2 python=3.8.15


### PR DESCRIPTION
Commit 5c1dc3e added another feature to Vamb, namely absolute abundances. AAMB, however, does not (yet) use this feature. However, it still uses the same data- loader Vamb does. Hence, it failed when it tried to iterate the dataloader with the wrong number of elements.
The bug is fixed in this PR, but there are several underlying issues here that need to be fixed:
* The AVAMB installation instructions recommended installing Vamb from the master branch. This has also been changed in this PR to install the latest version.
* There are no tests for AVAMB, meaning regressions like these go unnoticed.

Closes #223 

CC @Paupiera - can you run a simple AVAMB workflow and verify that it still works? Maybe just a few epochs. 