### PR TITLE
Update readme to mention several programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,34 +2,26 @@
 
 Created by Jakob Nybo Nissen and Simon Rasmussen, Technical University of Denmark and Novo Nordisk Foundation Center for Protein Research, University of Copenhagen.
 
-Vamb is a metagenomic binner which feeds sequence composition information from a contig catalogue and co-abundance information from BAM files into a variational autoencoder and clusters the latent representation. It performs excellently with multiple samples, and pretty good on single-sample data. Vamb is implemented purely in Python (with a little bit of Cython) and can be used both from command line and from within a Python interpreter.
+Vamb is a metagenomic binner which feeds sequence composition information from a contig catalogue and co-abundance information from BAM files into a variational autoencoder and clusters the latent representation. It performs excellently with multiple samples, and pretty good on single-sample data.
 
-:star: Vamb is benchmarked in CAMI2. Read our interpretations of the results [here.](https://github.com/RasmussenLab/vamb/blob/master/doc/CAMI2.md) :star:
+For more information about the implementation, methodological considerations, and advanced usage of Vamb, see [Vamb tutorial](https://github.com/RasmussenLab/vamb/blob/master/doc/tutorial.md).
 
-For more information about the implementation, methodological considerations, and advanced usage of Vamb, see the [Vamb paper in Nature Biotechnology](https://doi.org/10.1038/s41587-020-00777-4), a [blog post](https://go.nature.com/2JzYUvI) by Jakob on the development of Vamb, and the [Vamb tutorial](https://github.com/RasmussenLab/vamb/blob/master/doc/tutorial.md).
+## Programs in Vamb
+The Vamb package contains several programs, including three binners:
+* __Vamb__: The original binner based on variational autoencoders. [Article](https://doi.org/10.1038/s41587-020-00777-4)
+* __Avamb__: An ensemble model based on Vamb and adversarial autoencoders. [Article](https://doi.org/10.1038/s42003-023-05452-3).
+  Avamb produces somewhat better bins than Vamb, but is a more complex and computationally demanding pipeline.
+  See the [Avamb README page](https://github.com/RasmussenLab/avamb/tree/avamb_new/workflow_avamb) for more information.
+* __TaxVamb__: A semi-supervised binner that uses taxonomy information from e.g. `mmseqs taxonomy`. [Article still in the works].
+  TaxVamb produces superior bins, but requires you have run a taxonomic annotation workflow.
 
-:mega: Interested on maximizing the number of high quality bins from your samples?
-Please check out Avamb.
-Avamb is a metagenomics binning pipeline composed by Vamb and Aamb, an adversarial autoencoder for metagenomics binning, as well as a bin dereplication and quality filtering step that runs CheckM2.
-Similar to Vamb, Avamb leverages sequence composition information from a contig catalogue and co-abundance information from BAM files by projecting those features into  latent spaces, where the metagenomics binning actually takes place.
-Avamb has shown to reconstruct 23% more high quality bins as well as to increase the bins quality.
-For more information, please check the [Avamb snakemake page](https://github.com/RasmussenLab/avamb/tree/avamb_new/workflow_avamb).
-
-The Avamb pre-print can be found here [biorxiv](https://doi.org/10.1101/2023.02.27.527078). 
-
-:mega: Are your contigs annotated with taxonomy? Use Taxometer for refining the annotations and TaxVAMB for taxonomy-informed binning. 
-```
-vamb taxometer --outdir path/to/outdir --fasta /path/to/catalogue.fna.gz --bamfiles /path/to/bam/*.bam --taxonomy /path/to/taxonomy.tsv
-vamb bin taxvamb --outdir path/to/outdir --fasta /path/to/catalogue.fna.gz --bamfiles /path/to/bam/*.bam --taxonomy /path/to/taxonomy.tsv -o C
-```
-Taxometer preprint (link)
-
-TaxVAMB preprint (link)
+And a taxonomy predictor:
+* __Taxometer__: This tool refines arbitrary taxonomy predictions (e.g. from `mmseqs taxonomy`) using kmer composition and co-abundance. [Article still in the works].
 
 # Installation
+Vamb is in continuous development. Make sure to install the latest version for the best results.
 
 ### Installation for casual users:
-
 Recommended: Vamb can be installed with pip (thanks to contribution from C. Titus Brown):
 ```
 pip install vamb
@@ -38,7 +30,7 @@ pip install vamb
 :bangbang: An active Conda environment can hijack your system's linker, causing an error during installation. Either deactivate `conda`, or delete the `~/miniconda/compiler_compats` directory before installing with pip.
 
 Alternatively, it can be installed as a [Bioconda's package](https://anaconda.org/bioconda/vamb) (thanks to contribution from Antônio Pedro Camargo).
-Currently, the Conda version lags behind the pip version, so we recommend using pip. The BioConda package does not include GPU support.
+Currently, the Conda version is severely outdated, so we recommend installing using pip. Also, the BioConda package does not include GPU support.
  
 ```
 conda install -c pytorch pytorch torchvision cudatoolkit=10.2
@@ -46,7 +38,6 @@ conda install -c bioconda vamb
 ```
 
 ### Installation for advanced users:
-
 If you want to install the latest version from GitHub, or you want to change Vamb's source code, you should install it like this:
 
 ```
@@ -56,25 +47,33 @@ cd vamb
 pip install -e .
 ```
 
-__note that the master branch is work-in-progress and is expected to have more bugs__
+__Note that the master branch is work-in-progress and is expected to have more bugs__
 
 ### Installing by compiling the Cython yourself
 
-If you can't/don't want to use pip/Conda, you can do it the hard way: Get the most recent versions of the Python packages `cython`, `numpy`, `torch` and `pycoverm`. Compile `src/_vambtools.pyx` then move the resulting binary to the inner of the two `vamb` directories. Check if it works by importing `vamb` in a Python session.
+If you can't/don't want to use pip/Conda, you can do it the hard way: Install the dependencies listed in the `pyproject.toml` file. Compile `src/_vambtools.pyx` then move the resulting binary to the inner of the two `vamb` directories. Check if it works by importing `vamb` in a Python session.
 
-# Running
-For more detailed description of the recommended workflow, see the tutorial in the `doc` directory. 
+# Running Vamb
+First, figure out what program you want to run:
+* If you want to refine existing taxonomic classification, run `vamb taxometer`
+* If you want to bin, and is able to get taxonomic information, run `vamb bin taxvamb`
+* If you want to bin, and don't mind a more complex, but performant workflow run the [Avamb Snakemake workflow](https://github.com/RasmussenLab/avamb/tree/avamb_new/workflow_avamb)
+* If you want a decent and simple binner, run `vamb bin default`
 
 For more command-line options, see the command-line help menu:
 ```
 vamb -h
 ```
 
-To run, Vamb needs a FASTA file with contigs from one or more samples, and a set of BAM files, one from each sample, with reads mapped to the same FASTA file.
+To run, Vamb needs certain input files:
+* A FASTA file with contigs from one or more samples
+* A set of BAM files, one from each sample, with reads mapped to the same FASTA file.
+Further, TaxVamb specifically requires
+* Taxonomic annotation.
+
 You can either create the input files using your own workflow before calling Vamb, or you can use the Snakemake workflow included in Vamb to automatically create the input files before running Vamb.
 
 ## How to run: Using your own input files
-
 For this example, let us suppose you have a directory of  reads in a
 directory `/path/to/reads`, and that _you have already quality controlled them_.
 
@@ -107,7 +106,6 @@ vamb bin basic --outdir path/to/outdir --fasta /path/to/catalogue.fna.gz --bamfi
 5. Apply any desired postprocessing to Vamb's output.
 
 ## How to run: Using the Vamb Snakemake workflow
-
 To make it even easier to run Vamb, we have created a [Snakemake](https://snakemake.readthedocs.io/en/stable/#) workflow.
 This workflow runs steps 2-5 above using `minimap2` to align, and [CheckM](https://ecogenomics.github.io/CheckM/) to estimate completeness and contamination of the resulting bins.
 The workflow can run both on a local machine, a workstation and a HPC system using `qsub`. It can be found in the `workflow` folder - see the file `workflow/README.md` for details.


### PR DESCRIPTION
Structure README so it's clearer for users what subprograms Vamb is composed of. The README needs several more passes when the UX is getting overhauled.