### PR TITLE
Print help if only typing `vamb bin`

### DIFF
--- a/vamb/__main__.py
+++ b/vamb/__main__.py
@@ -2310,6 +2310,9 @@ def main():
     if args.subcommand == TAXOMETER:
         runner = TaxometerArguments(args)
     elif args.subcommand == BIN:
+        if args.model_subcommand is None:
+            vaevae_parserbin_parser.print_help()
+            sys.exit(1)
         classes_map = {
             VAMB: VAEArguments,
             AVAMB: VAEAAEArguments,


### PR DESCRIPTION
Previously, `vamb bin` would cause an internal parser error. Now, instead, do the same as `vamb bin -h`, i.e. print the help, and exit with error code 1.