### PR TITLE
Warn users on too few contigs

### DIFF
--- a/test/test_encode.py
+++ b/test/test_encode.py
@@ -157,10 +157,6 @@ class TestVAE(unittest.TestCase):
         t = self.tnfs.copy()
         l = self.lens.copy()
 
-        with self.assertWarns(UserWarning):
-            dl = vamb.encode.make_dataloader(r, t, l, batchsize=256)
-            vae.trainmodel(dl, batchsteps=None, nepochs=2)
-
     def test_loss_falls(self):
         vae = vamb.encode.VAE(self.rpkm.shape[1])
         rpkm_copy = self.rpkm.copy()

--- a/test/test_parsecontigs.py
+++ b/test/test_parsecontigs.py
@@ -2,6 +2,7 @@ import io
 import unittest
 import random
 import numpy as np
+import warnings
 
 import testtools
 from vamb.parsecontigs import Composition, CompositionMetaData
@@ -9,6 +10,7 @@ from vamb.parsecontigs import Composition, CompositionMetaData
 
 class TestReadContigs(unittest.TestCase):
     records = []
+    large_io = io.BytesIO()
     io = io.BytesIO()
 
     @classmethod
@@ -21,8 +23,14 @@ class TestReadContigs(unittest.TestCase):
             cls.io.write(i.format().encode())
             cls.io.write(b"\n")
 
+        for i in range(25_000):
+            record = testtools.make_randseq(rng, 250, 300)
+            cls.large_io.write(record.format().encode())
+            cls.large_io.write(b"\n")
+
     def setUp(self):
         self.io.seek(0)
+        self.large_io.seek(0)
 
     def test_unique_names(self):
         with self.assertRaises(ValueError):
@@ -33,9 +41,22 @@ class TestReadContigs(unittest.TestCase):
                 1000,
             )
 
+    # Does not warn
+    def test_nowarn(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            Composition.from_file(self.large_io, minlength=250)
+
+    def test_warns_n_contigs(self):
+        with self.assertWarns(UserWarning):
+            Composition.from_file(self.io, minlength=250)
+
     def test_filter_minlength(self):
         minlen = 500
-        composition = Composition.from_file(self.io, minlength=450)
+
+        with self.assertWarns(UserWarning):
+            composition = Composition.from_file(self.io, minlength=450)
+
         md = composition.metadata
         hash1 = md.refhash
 
@@ -74,7 +95,8 @@ class TestReadContigs(unittest.TestCase):
             Composition.from_file(self.io, minlength=3)
 
     def test_properties(self):
-        composition = Composition.from_file(self.io, minlength=420)
+        with self.assertWarns(UserWarning):
+            composition = Composition.from_file(self.io, minlength=420)
         passed = list(filter(lambda x: len(x.sequence) >= 420, self.records))
 
         self.assertEqual(composition.nseqs, len(composition.metadata.identifiers))
@@ -96,7 +118,8 @@ class TestReadContigs(unittest.TestCase):
 
     def test_save_load(self):
         buf = io.BytesIO()
-        composition_1 = Composition.from_file(self.io)
+        with self.assertWarns(UserWarning):
+            composition_1 = Composition.from_file(self.io)
         md1 = composition_1.metadata
         composition_1.save(buf)
         buf.seek(0)
@@ -126,8 +149,10 @@ class TestReadContigs(unittest.TestCase):
 
         buf1.seek(0)
         buf2.seek(0)
-        comp1 = Composition.from_file(buf1)
-        comp2 = Composition.from_file(buf2)
+        with self.assertWarns(UserWarning):
+            comp1 = Composition.from_file(buf1)
+        with self.assertWarns(UserWarning):
+            comp2 = Composition.from_file(buf2)
 
         self.assertEqual(comp1.metadata.refhash, comp2.metadata.refhash)
         self.assertTrue(np.all(comp1.matrix == comp2.matrix))

--- a/vamb/__main__.py
+++ b/vamb/__main__.py
@@ -524,7 +524,7 @@ def calc_tnf(
         log(f"Loading data from FASTA file {path}", logfile, 1)
         with vamb.vambtools.Reader(str(path)) as file:
             composition = vamb.parsecontigs.Composition.from_file(
-                file, minlength=options.min_contig_length
+                file, minlength=options.min_contig_length, logfile=logfile
             )
         composition.save(outdir.joinpath("composition.npz"))
 

--- a/vamb/encode.py
+++ b/vamb/encode.py
@@ -9,7 +9,6 @@ from torch.optim import Adam as _Adam
 from torch import Tensor
 from torch import nn as _nn
 from math import log as _log
-import warnings
 
 __doc__ = """Encode a depths matrix and a tnf matrix to latent representation.
 
@@ -86,14 +85,6 @@ def make_dataloader(
 
     if not (rpkm.dtype == tnf.dtype == _np.float32):
         raise ValueError("TNF and RPKM must be Numpy arrays of dtype float32")
-
-    if len(rpkm) < 20000:
-        warnings.warn(
-            f"WARNING: Creating DataLoader with only {len(rpkm)} sequences. "
-            "We normally expect 20,000 sequences or more to prevent overfitting. "
-            "As a deep learning model, VAEs are prone to overfitting with too few sequences. "
-            "You may want to lower the beta parameter, or use a different binner altogether."
-        )
 
     # Copy if not destroy - this way we can have all following operations in-place
     # for simplicity

--- a/vamb/vambtools.py
+++ b/vamb/vambtools.py
@@ -13,6 +13,18 @@ from hashlib import md5 as _md5
 from collections.abc import Iterable, Iterator, Generator
 from typing import Optional, IO, Union
 from pathlib import Path
+import warnings
+
+
+def showwarning_override(message, category, filename, lineno, file=None, line=None):
+    print(str(message) + "\n", file=file)
+
+
+# It may seem horrifying to override a stdlib method, but this is the way recommended by the
+# warnings documentation.
+# We do it because it's the only way I know to prevent displaying file numbers and source
+# code to our users, which I think is a terrible user experience
+warnings.showwarning = showwarning_override
 
 
 class PushArray:


### PR DESCRIPTION
Now warn users already when parsing contigs if they have fewer than 20,000 sequences, in order to prevent users from accidentally overfit the VAE.