### PR TITLE
Enforce `max_clusters` is not set with VAEAAE model

### DIFF
--- a/vamb/__main__.py
+++ b/vamb/__main__.py
@@ -1604,6 +1604,17 @@ class BinnerArguments(BasicArguments):
 class VAEAAEArguments(BinnerArguments):
     def __init__(self, args):
         super(VAEAAEArguments, self).__init__(args)
+
+        # For the VAE-AAE workflow, we must cluster the full set of sequences,
+        # else the cluster dereplication step makes no sense, as the different
+        # clusterings will contain different sets of clusters.
+        # So, enforce this here
+        if self.cluster_options.max_clusters is not None:
+            raise ValueError(
+                "When using the VAE-AAE model, `max_clusters` (option `-c`) "
+                "must not be set."
+            )
+
         self.aae_options = AAEOptions(
             nhiddens=args.nhiddens_aae,
             nlatent_z=args.nlatent_aae_z,


### PR DESCRIPTION
In `__main__.py`, the AAE Y and AAE Z clusters are both written to a clusters file. However, if I understand correctly, training the AAE latent directly gives you the full clustering of the AAE Y latent space. In contrast, the AAE Z latent space requires running the clustering algorithm.
However, if a user sets `-c` (i.e. limits the number of output clusters), then Y and Z will differ in that Y contains the full set of clusters and Z only a subset.

The solution in this PR is to simply disallow the `-c` option together with the `vae-aae` model.

CC @Paupiera - can you review (and approve and/or comment on) this bugfix?