### PR TITLE
Output cluster metadata in separate file

### DIFF
--- a/test/test_cluster.py
+++ b/test/test_cluster.py
@@ -1,8 +1,6 @@
 import unittest
 import numpy as np
 from hashlib import md5
-import random
-import string
 
 import vamb
 
@@ -91,39 +89,3 @@ class TestClusterer(unittest.TestCase):
     def test_cluster(self):
         x = next(vamb.cluster.ClusterGenerator(self.data, self.lens))
         self.assertIsInstance(x.members, np.ndarray)
-        med, st = x.as_tuple()
-        self.assertIsInstance(st, set)
-        self.assertEqual(set(x.members), st)
-        self.assertIn(med, st)
-
-
-class TestPairs(unittest.TestCase):
-    rng = np.random.RandomState(6)
-    n_samples = 1024
-    data = rng.random((n_samples, 40)).astype(np.float32)
-    lens = rng.randint(500, 1000, size=1024)
-
-    @staticmethod
-    def randstring(len):
-        return "".join(random.choices(string.ascii_letters, k=len))
-
-    def test_too_few_names(self):
-        clstr = vamb.cluster.ClusterGenerator(self.data, self.lens)
-        nameset = {self.randstring(10) for i in range(len(self.data) - 1)}
-        with self.assertRaises(ValueError):
-            list(vamb.cluster.pairs(clstr, list(nameset)))
-
-    def test_pairs(self):
-        clstr = vamb.cluster.ClusterGenerator(self.data, self.lens)
-        nameset = {self.randstring(10) for i in range(len(self.data))}
-        pairs = list(vamb.cluster.pairs(clstr, list(nameset)))
-
-        medoid, members = pairs[0]
-        self.assertIsInstance(medoid, str)
-        self.assertIsInstance(members, set)
-        self.assertTrue(all(len(i[1]) > 0 for i in pairs))
-        self.assertTrue(sum(map(lambda i: len(i[1]), pairs)), len(nameset))
-        allmembers = set()
-        for medoid, mems in pairs:
-            allmembers.update(mems)
-        self.assertEqual(allmembers, nameset)

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -147,7 +147,8 @@ class TestClusterResult(unittest.TestCase):
             # Uncomment when updating this test.
             # lens = list()
             for cluster in vamb.cluster.ClusterGenerator(self.latent.copy()):
-                medoid, points = cluster.as_tuple()
+                medoid = cluster.metadata.medoid
+                points = set(cluster.members)
                 # Set hashing may differ from run to run, so turn into sorted arrays
                 arr = np.array(list(points))
                 arr.sort()

--- a/vamb/__main__.py
+++ b/vamb/__main__.py
@@ -13,7 +13,7 @@ import random
 import pycoverm
 import itertools
 from math import isfinite
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, cast
 from pathlib import Path
 from collections.abc import Sequence
 from collections import defaultdict
@@ -757,17 +757,30 @@ def cluster_and_write_files(
         cuda=vamb_options.cuda,
         rng_seed=vamb_options.seed,
     )
-
-    renamed = (
-        (str(cluster_index + 1), {sequence_names[i] for i in members})
-        for (cluster_index, (_, members)) in enumerate(
-            map(lambda x: x.as_tuple(), cluster_generator)
-        )
-    )
-
     # This also works correctly when max_clusters is None
-    first_clusters = itertools.islice(renamed, cluster_options.max_clusters)
-    unsplit_clusters = dict(first_clusters)
+    clusters = itertools.islice(cluster_generator, cluster_options.max_clusters)
+    cluster_dict: dict[str, set[str]] = dict()
+
+    # Write the cluster metadata to file
+    with open(Path(base_clusters_name + "_metadata.tsv"), "w") as file:
+        print("name\tradius\tpeak valley ratio\tkind\tbp\tncontigs", file=file)
+        for i, cluster in enumerate(clusters):
+            cluster_dict[str(i + 1)] = {
+                sequence_names[cast(int, i)] for i in cluster.members
+            }
+            print(
+                str(i + 1),
+                None if cluster.radius is None else round(cluster.radius, 3),
+                None
+                if cluster.observed_pvr is None
+                else round(cluster.observed_pvr, 2),
+                cluster.kind_str,
+                sum(sequence_lens[i] for i in cluster.members),
+                len(cluster.members),
+                file=file,
+                sep="\t",
+            )
+
     elapsed = round(time.time() - begintime, 2)
 
     write_clusters_and_bins(
@@ -776,7 +789,7 @@ def cluster_and_write_files(
         base_clusters_name,
         bins_dir,
         fasta_catalogue,
-        unsplit_clusters,
+        cluster_dict,
         sequence_names,
         sequence_lens,
     )


### PR DESCRIPTION
The overall idea here is that we output more metadata about generated clusters, allowing our users to more easily get an idea of the cluster quality.

I would like to ping off ideas around this with you guys.

See #240

Based on #251, though the changes are small enough that they can be cherry-picked to existing master if necessary