### PR TITLE
Use loguru as logging framework

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "scikit-learn == 1.2.2",
     "pandas == 2.0.0",
     "dadaptation == 3.0",
+    "loguru == 0.7.2",
 ]
 # Currently pycoverm does not have binaries for Python > 3.11.
 # The dependency resolver, will not error on Python 3.11, but attempt

--- a/test/test_aamb_encode.py
+++ b/test/test_aamb_encode.py
@@ -1,8 +1,6 @@
 import unittest
 import numpy as np
-import io
 import random
-
 import vamb
 
 
@@ -55,7 +53,6 @@ class TestAAE(unittest.TestCase):
         (di, ti, ai, we) = next(iter(dl))
         mu, do, to, _, _, _, _ = aae(di, ti)
         start_loss = aae.calc_loss(di, do, ti, to)[0].data.item()
-        iobuffer = io.StringIO()
 
         # Loss drops with training
         aae.trainmodel(
@@ -64,7 +61,6 @@ class TestAAE(unittest.TestCase):
             batchsteps=[1, 2],
             T=self.default_temperature,
             lr=self.default_lr,
-            logfile=iobuffer,
             modelfile=None,
         )
         mu, do, to, _, _, _, _ = aae(di, ti)

--- a/test/test_encode.py
+++ b/test/test_encode.py
@@ -2,8 +2,6 @@ import unittest
 import numpy as np
 import torch
 import tempfile
-import io
-
 import vamb
 
 
@@ -161,13 +159,10 @@ class TestVAE(unittest.TestCase):
         (di, ti, ai, we) = next(iter(dl))
         do, to, ao, mu = vae(di, ti, ai)
         start_loss = vae.calc_loss(di, do, ti, to, ao, ai, mu, we)[0].data.item()
-        iobuffer = io.StringIO()
 
         with tempfile.TemporaryFile() as file:
             # Loss drops with training
-            vae.trainmodel(
-                dl, nepochs=3, batchsteps=[1, 2], logfile=iobuffer, modelfile=file
-            )
+            vae.trainmodel(dl, nepochs=3, batchsteps=[1, 2], modelfile=file)
             do, to, ao, mu = vae(di, ti, ai)
             end_loss = vae.calc_loss(di, do, ti, to, ao, ai, mu, we)[0].data.item()
             self.assertLess(end_loss, start_loss)

--- a/test/test_semisupervised_encode.py
+++ b/test/test_semisupervised_encode.py
@@ -1,8 +1,6 @@
 import unittest
 import numpy as np
 import tempfile
-import io
-
 import vamb
 
 
@@ -76,7 +74,6 @@ class TestVAEVAE(unittest.TestCase):
                     self.assertTrue(table_parent[ind_nodes[c]] == ind_nodes[p])
 
     def test_encoding(self):
-        iobuffer = io.StringIO()
         nlatent = 10
         batchsize = 10
         nepochs = 2
@@ -93,7 +90,6 @@ class TestVAEVAE(unittest.TestCase):
             table_parent,
             nlatent=nlatent,
             cuda=False,
-            logfile=iobuffer,
         )
 
         dataloader_vamb = vamb.encode.make_dataloader(
@@ -141,7 +137,6 @@ class TestVAEVAE(unittest.TestCase):
                 dataloader,
                 nepochs=nepochs,
                 modelfile=modelfile,
-                logfile=iobuffer,
                 batchsteps=[],
             )
 

--- a/test/test_vambtools.py
+++ b/test/test_vambtools.py
@@ -416,8 +416,8 @@ class TestBinSplit(unittest.TestCase):
             b.initialize(["AXC", "S1C2"])
 
         b = BinSplitter(None)
-        with self.assertWarns(UserWarning):
-            b.initialize(["S1C2", "ABC"])
+        b.initialize(["S1C2", "ABC"])
+        self.assertEqual(b.splitter, None)
 
         b = BinSplitter(None)
         b.initialize(["S1C2", "KMCPLK"])

--- a/vamb/__init__.py
+++ b/vamb/__init__.py
@@ -17,6 +17,10 @@ from . import hlosses_fast
 from . import infer
 from . import reclustering
 
+from loguru import logger
+
+logger.remove()
+
 __all__ = [
     "vambtools",
     "parsebam",

--- a/vamb/parsecontigs.py
+++ b/vamb/parsecontigs.py
@@ -9,7 +9,7 @@ import os as _os
 import numpy as _np
 import vamb.vambtools as _vambtools
 from collections.abc import Iterable, Sequence
-from typing import IO, Union, TypeVar, Optional
+from typing import IO, Union, TypeVar
 from pathlib import Path
 
 # This kernel is created in src/create_kernel.py. See that file for explanation
@@ -162,14 +162,12 @@ class Composition:
         cls: type[C],
         filehandle: Iterable[bytes],
         minlength: int = 2000,
-        logfile: Optional[IO[str]] = None,
     ) -> C:
         """Parses a FASTA file open in binary reading mode, returning Composition.
 
         Input:
             filehandle: Filehandle open in binary mode of a FASTA file
             minlength: Ignore any references shorter than N bases [2000]
-            logfile: Logfile to print warning to, if any
         """
 
         if minlength < 4:

--- a/vamb/reclustering.py
+++ b/vamb/reclustering.py
@@ -7,7 +7,6 @@ import os
 import subprocess
 import sys
 import contextlib
-from typing import IO
 from sklearn.cluster import KMeans
 import numpy as np
 from collections import defaultdict
@@ -16,12 +15,8 @@ from sklearn.cluster import DBSCAN
 from sklearn.metrics import pairwise_distances
 import gzip
 import lzma
+from loguru import logger
 import vamb
-
-
-def log(string: str, logfile: IO[str], indent: int = 0):
-    print(("\t" * indent) + string, file=logfile)
-    logfile.flush()
 
 
 def get_best_bin(results_dict, contig_to_marker, namelist, contig_dict, minfasta):
@@ -361,7 +356,6 @@ def cal_num_bins(
 
 
 def recluster_bins(
-    logfile,
     clusters_path,
     latents_path,
     contigs_path,
@@ -400,10 +394,10 @@ def recluster_bins(
     for k, v in clusters_labels_map.items():
         labels_cluster_map[v].append(k)
     indices_contigs = {c: i for i, c in enumerate(contignames_all)}
-    log(f"Latent shape {embedding.shape}", logfile, 1)
-    log(f"N contignames for the latent space {len(contignames_all)}", logfile, 1)
-    log(f"N contigs in fasta files {len(contig_dict)}", logfile, 1)
-    log(f"N contigs in the cluster file {len(clusters_labels_map)}", logfile, 1)
+    logger.info(f"\tLatent shape {embedding.shape}")
+    logger.info(f"\tN contignames for the latent space {len(contignames_all)}")
+    logger.info(f"\tN contigs in fasta files {len(contig_dict)}")
+    logger.info(f"\tN contigs in the cluster file {len(clusters_labels_map)}")
 
     contig_labels = np.array([clusters_labels_map[c] for c in contignames_all])
 
@@ -422,10 +416,10 @@ def recluster_bins(
             concat_out.write(f">bin{bin_ix:06}.{h}\n")
             concat_out.write(contig_dict[contignames_all[ix]] + "\n")
 
-    log("Starting searching for markers", logfile, 1)
+    logger.info("\tStarting searching for markers")
 
     if hmmout_path is not None:
-        log(f"hmmout file is provided at {hmmout_path}", logfile, 2)
+        logger.info(f"\t\thmmout file is provided at {hmmout_path}")
         seeds = cal_num_bins(
             cfasta,
             binned_length,
@@ -445,10 +439,10 @@ def recluster_bins(
         )
     # we cannot bypass the orf_finder here, because of the renaming of the contigs
     if seeds == []:
-        log("No bins found in the concatenated fasta file.", logfile, 1)
+        logger.info("\tNo bins found in the concatenated fasta file.")
         return contig_labels
-    log("Finished searching for markers", logfile, 1)
-    log(f"Found {len(seeds)} seeds", logfile, 1)
+    logger.info("\tFinished searching for markers")
+    logger.info(f"\tFound {len(seeds)} seeds")
 
     if algorithm == "dbscan":
         contig2marker = get_marker(
@@ -459,10 +453,10 @@ def recluster_bins(
             clusters_dict=clusters_labels_map,
             contig_to_marker=True,
         )
-        log("Running DBSCAN with cosine distance", logfile, 1)
+        logger.info("\tRunning DBSCAN with cosine distance")
         extracted_all = []
         for k, v in labels_cluster_map.items():
-            log(f"Label {k}, {len(v)} contigs", logfile, 1)
+            logger.info(f"\tLabel {k}, {len(v)} contigs")
             indices = [indices_contigs[c] for c in v]
             contignames = contignames_all[indices]
             embedding_new = embedding[indices]
@@ -480,10 +474,10 @@ def recluster_bins(
                 )
                 dbscan.fit(distance_matrix, sample_weight=length_weight)
                 labels = dbscan.labels_
-                log(f"epsilon {eps_value}, {len(set(labels))} labels", logfile, 2)
+                logger.info(f"\t\tepsilon {eps_value}, {len(set(labels))} labels")
                 DBSCAN_results_dict[eps_value] = labels.tolist()
 
-            log("Integrating results", logfile, 1)
+            logger.info("\tIntegrating results")
 
             extracted = []
             contignames_list = list(contignames)
@@ -513,7 +507,7 @@ def recluster_bins(
             extracted_all.extend(extracted)
 
         contig2ix = {}
-        log(f"{len(extracted_all)} extracted clusters", logfile, 1)
+        logger.info(f"\t{len(extracted_all)} extracted clusters")
         for i, cs in enumerate(extracted_all):
             for c in cs:
                 contig2ix[c] = i
@@ -543,7 +537,7 @@ def recluster_bins(
                     ]
                 )
                 seeds_embedding = embedding[seed_index]
-                log(f"Starting K-means reclutering for bin {bin_ix}", logfile, 2)
+                logger.info(f"\t\tStarting K-means reclutering for bin {bin_ix}")
                 kmeans = KMeans(
                     n_clusters=num_bin,
                     init=seeds_embedding,
@@ -551,7 +545,7 @@ def recluster_bins(
                     random_state=random_seed,
                 )
                 kmeans.fit(re_bin_features, sample_weight=length_weight)
-                log("Finished K-means reclutering", logfile, 2)
+                logger.info("\t\tFinished K-means reclutering")
                 for i, label in enumerate(kmeans.labels_):
                     contig_labels_reclustered[contig_indices[i]] = next_label + label
                 next_label += num_bin


### PR DESCRIPTION
Before, Vamb did not use a logging framework, but printed to a logfile, which was passed to every function that needed to log. This had several issues:
* Logging was only printed to the logfile, not stderr,
* Logging was hard to customize, since you needed to customize 100s of print statements instead of a central logger object
* Lots of functions needed to take a logger as an argument, when really a logger is global state and needs to be treated as such
* There were no timestamps in the logging

All of these points are now addressed.

## TODO
- [x] Format the logfile nicer