### PR TITLE
Cleanup clustering

### DIFF
--- a/test/test_cluster.py
+++ b/test/test_cluster.py
@@ -8,8 +8,11 @@ import vamb
 
 
 class TestClusterer(unittest.TestCase):
-    data = np.random.random((1024, 40)).astype(np.float32)
-    lens = np.random.randint(500, 1000, size=1024)
+    # This seed has been set just so the unit tests runs faster.
+    # How many iterations of the clustering depends on the input data
+    rng = np.random.RandomState(5)
+    data = rng.random((1024, 40)).astype(np.float32)
+    lens = rng.randint(500, 1000, size=1024)
 
     def test_bad_params(self):
         with self.assertRaises(ValueError):
@@ -33,19 +36,6 @@ class TestClusterer(unittest.TestCase):
             vamb.cluster.ClusterGenerator(
                 np.random.random((0, 40)), np.array([], dtype=int)
             )
-
-    # In the code, in __init__ of the cluster generator, the input matrix
-    # is shuffled, and an index array is permuted to keep track of which
-    # indices was which.
-    # This depends on the implementation of shuffling and permute being
-    # the same, which I test here.
-    def test_shuffling(self):
-        seed = 0
-        cp = self.data.copy()
-        np.random.Generator(np.random.PCG64(seed)).shuffle((cp))
-        indices = np.random.Generator(np.random.PCG64(seed)).permutation(len(cp))
-        cplike = self.data[indices]
-        self.assertTrue(np.all(cplike == cp))
 
     def test_basics(self):
         clstr = vamb.cluster.ClusterGenerator(self.data, self.lens)
@@ -108,9 +98,10 @@ class TestClusterer(unittest.TestCase):
 
 
 class TestPairs(unittest.TestCase):
+    rng = np.random.RandomState(6)
     n_samples = 1024
-    data = np.random.random((n_samples, 40)).astype(np.float32)
-    lens = np.random.randint(500, 1000, size=1024)
+    data = rng.random((n_samples, 40)).astype(np.float32)
+    lens = rng.randint(500, 1000, size=1024)
 
     @staticmethod
     def randstring(len):


### PR DESCRIPTION
This adds two commits:
* Refactor `sample_medoid` to be a method, not a function. This is part of another PR.
* Temporarily fix slow unit tests clustering by fiddling with the RNG seed