### PR TITLE
Cache sampling of medoid

### DIFF
--- a/vamb/cluster.py
+++ b/vamb/cluster.py
@@ -186,6 +186,8 @@ class ClusterGenerator:
         # On GPU, deleting rows is not feasable because that requires us to copy the matrix from and to the GPU,
         # so we instead use this array to mask away any point emitted in an earlier iteration.
         "kept_mask",
+        # This dict caches the computation of `sample_medoid`, which is the most compute heavy function
+        "medoid_cache",
     ]
 
     def __repr__(self) -> str:
@@ -296,6 +298,7 @@ class ClusterGenerator:
         self.histogram = histogram
         self.histogram_edges = _torch.linspace(0.0, _XMAX, round(_XMAX / _DELTA_X) + 1)
         self.kept_mask = kept_mask
+        self.medoid_cache: dict[int, tuple[_Tensor, _Tensor, float]] = dict()
 
     # It's an iterator itself
     def __iter__(self):
@@ -307,6 +310,7 @@ class ClusterGenerator:
         assert self.n_remaining_points > 0  # not negative
 
         cluster, _, points = self.find_cluster()
+        self.medoid_cache.clear()
         self.n_emitted_clusters += 1
         self.n_remaining_points -= len(points)
 
@@ -431,7 +435,7 @@ class ClusterGenerator:
             sampled_medoid = candidates[i]
             tried.add(sampled_medoid)
             sample_cluster, sample_distances, sample_density = self.sample_medoid(
-                sampled_medoid
+                medoid
             )
 
             # If the mean distance of inner points of the sample is lower,
@@ -610,6 +614,9 @@ class ClusterGenerator:
         - A vector Xf distances to all points
         - The mean distance from medoid to the other points in the first vector
         """
+        existing = self.medoid_cache.get(medoid, None)
+        if existing is not None:
+            return existing
 
         distances = _calc_distances(self.matrix, medoid)
 
@@ -622,8 +629,10 @@ class ClusterGenerator:
 
         closeness = _MEDOID_RADIUS - distances[within_threshold]
         local_density = (self.lengths[within_threshold] * closeness).sum().item()
+        result = (cluster, distances, local_density)
+        self.medoid_cache[medoid] = result
 
-        return cluster, distances, local_density
+        return result
 
 
 def _smaller_indices(


### PR DESCRIPTION
This commit adds a cache to the sampling of the medoid in clustering. This allows the clusterer to fetch the results from a dict, if it's been previously computed. This will get merged only if benchmarks have verified that clustering actually runs faster - it's probable that so few medoids are sampled multiple times that the cache wastes more time in overhead than it saves in computation.