### PR TITLE
Output .tsv files in actual TSV format

### DIFF
--- a/test/test_vambtools.py
+++ b/test/test_vambtools.py
@@ -499,7 +499,8 @@ class TestWriteClusters(unittest.TestCase):
 
     def conforms(self, str, clusters):
         lines = self.linesof(str)
-        self.assertEqual(len(lines), sum(len(v) for (_, v) in clusters))
+        self.assertEqual(lines[0], vamb.vambtools.CLUSTERS_HEADER)
+        self.assertEqual(len(lines) - 1, sum(len(v) for (_, v) in clusters))
         allcontigs = set()
         printed = set()
         printed_names = set()
@@ -509,7 +510,7 @@ class TestWriteClusters(unittest.TestCase):
         for k, v in clusters:
             allcontigs.update(v)
 
-        for line in lines:
+        for line in lines[1:]:
             name, _, contig = line.partition("\t")
             printed.add(contig)
             printed_names.add(name)
@@ -534,7 +535,7 @@ class TestWriteClusters(unittest.TestCase):
     def test_max_clusters(self):
         vamb.vambtools.write_clusters(self.io, self.test_clusters[:2])
         lines = self.linesof(self.io.getvalue())
-        self.assertEqual(len(lines), 9)
+        self.assertEqual(len(lines), 10)
         self.conforms(self.io.getvalue(), self.test_clusters[:2])
 
 

--- a/workflow_avamb/src/manual_drep_JN.py
+++ b/workflow_avamb/src/manual_drep_JN.py
@@ -63,6 +63,7 @@ def main(
         raise FileExistsError(outpath)
 
     with open(outpath, "w") as file:
+        print(vamb.vambtools.CLUSTERS_HEADER, file=file)
         for bin in dereplicated:
             bin_name = bin_names[bin]
             bin_name = bin_name.replace(".fna", "")

--- a/workflow_avamb/src/mv_bins_from_mdrep_clusters.py
+++ b/workflow_avamb/src/mv_bins_from_mdrep_clusters.py
@@ -108,6 +108,7 @@ def write_final_nc_clusters(
     path_nc_clusters: str,
 ):
     with open(path_nc_clusters, "w") as file:
+        print(vamb.vambtools.CLUSTERS_HEADER, file=file)
         for nc_cluster in cluster_scores.keys():
             nc_contigs = cluster_contigs[nc_cluster]
             for nc_contig in nc_contigs:

--- a/workflow_avamb/src/rip_bins.py
+++ b/workflow_avamb/src/rip_bins.py
@@ -70,6 +70,7 @@ def main(
             del cluster_contigs_not_ripped[cluster]
 
     with open(path_clusters_not_ripped, "w") as file:
+        print(vamb.vambtools.CLUSTERS_HEADER, file=file)
         for cluster, contigs_nr in cluster_contigs_not_ripped.items():
             contigs_o = cluster_contigs_original[cluster]
             if contigs_o != contigs_nr:

--- a/workflow_avamb/src/write_clusters_from_dereplicated_and_ripped_bins.sh
+++ b/workflow_avamb/src/write_clusters_from_dereplicated_and_ripped_bins.sh
@@ -23,6 +23,7 @@ then
 
 cluster_name=$(echo $bin | sed 's=.fna==g' | sed 's=.fa==g')
 
+echo -e   "clustername\tcontigname"  >> $output_file
 for contig in $(grep '>' $bin | sed 's=>==g')
 do
 echo -e   "$cluster_name""\t""$contig"  >> $output_file


### PR DESCRIPTION
It turns out TSV has an actual specification, see
https://www.iana.org/assignments/media-types/text/tab-separated-values and https://www.loc.gov/preservation/digital/formats/fdd/fdd000533.shtml#notes However, Vamb did not follow this specification, as the header line was missing. This is problematic, because external TSV parsers may not correctly parse the output files. It's also just annoying for users.

In this commit, add a header line to all output .TSV files. This is a breaking change, so let's get it in before v5.