### PR TITLE
Bugfix: Check for zero TNFs before projection

### DIFF
--- a/test/test_parsecontigs.py
+++ b/test/test_parsecontigs.py
@@ -31,6 +31,16 @@ class TestReadContigs(unittest.TestCase):
         self.io.seek(0)
         self.large_io.seek(0)
 
+    def test_only_ns(self):
+        file = io.BytesIO()
+        file.write(b">abc\n")
+        file.write(b"N" * 2500)
+        file.write(b"\n")
+        file.seek(0)
+
+        with self.assertRaises(ValueError):
+            Composition.from_file(file)
+
     def test_unique_names(self):
         with self.assertRaises(ValueError):
             CompositionMetaData(

--- a/vamb/encode.py
+++ b/vamb/encode.py
@@ -99,17 +99,6 @@ def make_dataloader(
             "One or more samples have zero depth in all sequences, so cannot be depth normalized"
         )
     rpkm *= 1_000_000 / sample_depths_sum
-
-    zero_tnf = tnf.sum(axis=1) == 0
-    smallest_index = _np.argmax(zero_tnf)
-    if zero_tnf[smallest_index]:
-        raise ValueError(
-            f"TNF row at index {smallest_index} is all zeros. "
-            + "This implies that the sequence contained no 4-mers of A, C, G, T or U, "
-            + "making this sequence uninformative. This is probably a mistake. "
-            + "Verify that the sequence contains usable information (e.g. is not all N's)"
-        )
-
     total_abundance = rpkm.sum(axis=1)
 
     # Normalize rpkm to sum to 1


### PR DESCRIPTION
Before, when creating the dataloader, we raised an error if any contigs had observed zero TNFs, since this would imply a sequence that was only composed of ambiguous nucleotides, and thus an uninformative sequence (and almost certainly also a mistake in the input).
However, since this check was in the data loader, the check happened on the *projected* TNF space, and so the check for a sum of zero was meaningless. Indeed, not only would this error not be triggered when an actual zero TNF seq was observed, it would be falsely triggered in the very unlikely even that a sequence's projected TNF summed to exactly zero.

Closes #276 - cc @ChaoXianSen - to apply this bugfix on your current branch, you can simply delete the code in `vamb/encode.py` that raises the error.