### PR TITLE
Remove bad marker genes

### DIFF
--- a/vamb/reclustering.py
+++ b/vamb/reclustering.py
@@ -40,7 +40,7 @@ def get_best_bin(results_dict, contig_to_marker, namelist, contig_dict, minfasta
                     marker_list.extend(contig_to_marker[contig])
                 if len(marker_list) == 0:
                     continue
-                recall = len(set(marker_list)) / 107
+                recall = len(set(marker_list)) / 104
                 contamination = (len(marker_list) - len(set(marker_list))) / len(
                     marker_list
                 )


### PR DESCRIPTION
Experiments on downloaded genomes found that 2/3rds of duplicated SCGs were one of the three removed here.
Removing these SCGs will significantly improve the accuracy of SCG usage.