### PR TITLE
Remove overfitting warning

### DIFF
--- a/vamb/aamb_encode.py
+++ b/vamb/aamb_encode.py
@@ -1,6 +1,5 @@
 """Adversarial autoencoders (AAE) for metagenomics binning, this files contains the implementation of the AAE"""
 
-
 import numpy as np
 from math import log, isfinite
 import time

--- a/vamb/semisupervised_encode.py
+++ b/vamb/semisupervised_encode.py
@@ -1,6 +1,5 @@
 """Semisupervised multimodal VAEs for metagenomics binning, this files contains the implementation of the VAEVAE for MMSEQ predictions"""
 
-
 __cmd_doc__ = """Encode depths and TNF using a VAE to latent representation"""
 
 import numpy as _np

--- a/vamb/taxvamb_encode.py
+++ b/vamb/taxvamb_encode.py
@@ -1,6 +1,5 @@
 """Hierarchical loss for the labels suggested in https://arxiv.org/abs/2210.10929"""
 
-
 __cmd_doc__ = """Hierarchical loss for the labels"""
 
 

--- a/workflow_avamb/src/rip_bins.py
+++ b/workflow_avamb/src/rip_bins.py
@@ -183,9 +183,9 @@ def remove_meaningless_edges_from_pairs(
                     contig_length,
                 )
                 print("Cluster ripped because of a meaningless edge ", cluster_updated)
-                clusters_changed_but_not_intersecting_contigs[
-                    cluster_updated
-                ] = cluster_contigs[cluster_updated]
+                clusters_changed_but_not_intersecting_contigs[cluster_updated] = (
+                    cluster_contigs[cluster_updated]
+                )
 
     components: list[set[str]] = list()
     for component in nx.connected_components(graph_clusters):
@@ -295,9 +295,9 @@ def make_all_components_pair(
                     contig_length,
                 )
                 print("Cluster ripped because of a pairing component ", cluster_updated)
-                clusters_changed_but_not_intersecting_contigs[
-                    cluster_updated
-                ] = cluster_contigs[cluster_updated]
+                clusters_changed_but_not_intersecting_contigs[cluster_updated] = (
+                    cluster_contigs[cluster_updated]
+                )
                 component_len = max(
                     [
                         len(nx.node_connected_component(graph_clusters, node_i))


### PR DESCRIPTION
In experiments, we've been unable to show that Vamb overfits, even with datasets 10% the size of our smallest test dataset. We're not sure why, but it's probably because Vamb is extremely regularized already, and the regularization kicks in only with a low number of contigs.

Vamb might still overfit on high quality assemblies like HiFi data, if there are only a few thousand or few hundred contigs, but we cannot assess this until we get good benchmark datasets of this quality.