### PR TITLE
Add stderr logger early in main

### DIFF
--- a/vamb/__main__.py
+++ b/vamb/__main__.py
@@ -1398,7 +1398,6 @@ class BasicArguments(object):
         logger.add(
             self.vamb_options.out_dir.joinpath(self.LOGS_PATH), format=format_log
         )
-        logger.add(sys.stderr, format=format_log)
         begintime = time.time()
         logger.info("Starting Vamb version " + vamb.__version_str__)
         logger.info("Random seed is " + str(self.vamb_options.seed))
@@ -2064,6 +2063,8 @@ def main():
     vamb bin default --outdir out --fasta my_contigs.fna --bamfiles *.bam -o C
 
     Find the latest updates and documentation at https://github.com/RasmussenLab/vamb"""
+    logger.add(sys.stderr, format=format_log)
+
     parser = argparse.ArgumentParser(
         prog="vamb",
         description=doc,


### PR DESCRIPTION
Because we remove the default logger on init, but only add the new logger when run() is called, there is no logger available during the preprocessing steps, e.g. argparsing.
This leads to warnings not being shown to the user, which is very bad from a usability point of view.