### PR TITLE
Add useful error when passed < 2 sequences

### DIFF
--- a/vamb/encode.py
+++ b/vamb/encode.py
@@ -360,6 +360,14 @@ class VAE(_nn.Module):
         optimizer,
         batchsteps: list[int],
     ) -> _DataLoader[tuple[Tensor, Tensor, Tensor]]:
+        if len(data_loader.dataset.tensors[0]) < 2:
+            raise ValueError(
+                "Cannot train on a dataset with fewer than 2 sequences, but got "
+                f"{len(data_loader.dataset.tensors[0])} sequences. "
+                "If you are trying to fit a DL model to this few sequences, "
+                "something probably went wrong in your pipeline."
+            )
+
         self.train()
 
         epoch_loss = 0.0


### PR DESCRIPTION
This causes various errors in either the normalization when creating the data loader, or during training, as PyTorch treats singleton dimensions differently.
When Vamb is run from command line, throw an error early after parsing contigs, and when using the tool as a package, also throw it before training.

Closes #313 