### PR TITLE
Tweak some default parameters

### DIFF
--- a/vamb/__main__.py
+++ b/vamb/__main__.py
@@ -1783,8 +1783,8 @@ def add_vae_arguments(subparser):
         dest="beta",
         metavar="",
         type=float,
-        default=200.0,
-        help="beta, capacity to learn [200.0]",
+        default=500.0,
+        help="beta, capacity to learn [500.0]",
     )
     vaeos.add_argument(
         "-d",
@@ -1805,8 +1805,8 @@ def add_vae_arguments(subparser):
         dest="batchsize",
         metavar="",
         type=int,
-        default=256,
-        help="starting batch size [256]",
+        default=128,
+        help="starting batch size [128]",
     )
     trainos.add_argument(
         "-q",

--- a/vamb/encode.py
+++ b/vamb/encode.py
@@ -184,7 +184,7 @@ class VAE(_nn.Module):
 
         # If only 1 sample, we weigh alpha and nhiddens differently
         if alpha is None:
-            alpha = 0.15 if nsamples > 1 else 0.50
+            alpha = 0.25 if nsamples > 1 else 0.50
 
         if nhiddens is None:
             nhiddens = [512, 512] if nsamples > 1 else [256, 256]


### PR DESCRIPTION
Benchmarking has suggested than on the current version of Vamb, these parameters may be better.
This needs additional benchmarking.

I'm making this PR now so we don't forget. Importantly things to consider
* We should also test the optimal value of alpha for single-sample binning. This may have changed in recent versions of Vamb.
* The benchmarking for this PR is done on long reads. This may cause the optimal alpha to be overestimated. Confirm that a=0.25 is better for short reads, too.
* Since beta needed to be increased, we may consider upping the number of neurons in the latent layers, too.
* We should check the log files to see how much slower a starting batch size of 128 is compared to one of 256, on a dataset with longer reads. If the gain is sufficiently small, and the compute time large, we may skip this optimisation.

This also interacts with #180 which we still need to do.