### PR TITLE
Switch Black formatter to Ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,11 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: psf/black@stable
+      - uses: chartboost/ruff-action@v1
+          with:
+            version: 0.5.0
+            args: 'format --check'
+
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: chartboost/ruff-action@v1
           with:
-            version: 0.4.10
+            version: 0.5.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ A tag unambiguously refers to a commit, and is never removed.
 Ideally, the tagged commit should be the one that updates the version in `vamb/__init__.py`.
 
 #### Testing
-Our CI pipeline currently uses a formatter and a linter to check for issues (currently, the Black and Ruff formatter and linter).
+Our CI pipeline currently uses a formatter and a linter to check for issues (currently, the Ruff formatter and linter).
 To quicken development time, you can install these locally so you can catch these issues before they are caught in CI.
 
 #### Dependencies
@@ -60,11 +60,11 @@ $ git switch -c kmer-compression
 
 Write your code, then test it.
 This requires you to have installed Vamb (preferentially with `pip install -e .`),
-and installed `pytest`, `black` and `ruff`:
+and installed `pytest` and `ruff`:
 ```shell
 $ python -m pytest # test the code
 $ ruff check . # run the linter
-$ black . # run the formatter
+$ ruff format . # run the formatter
 ```
 
 Commit it, then push to `origin`

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -128,7 +128,7 @@ if os.environ.get("READTHEDOCS") == "True":
 
 #     def run_apidoc(_):
 #         from sphinx.ext import apidoc
-# 
+#
 #         apidoc.main(
 #             [
 #                 "--force",
@@ -142,6 +142,6 @@ if os.environ.get("READTHEDOCS") == "True":
 #                 str(PACKAGE_ROOT / "*.so"),
 #             ]
 #         )
-# 
+#
 #     def setup(app):
 #         app.connect("builder-inited", run_apidoc)

--- a/vamb/aamb_encode.py
+++ b/vamb/aamb_encode.py
@@ -260,7 +260,8 @@ class AAE(nn.Module):
         for epoch_i in range(nepochs):
             if epoch_i in batchsteps:
                 data_loader = set_batchsize(
-                    data_loader, data_loader.batch_size * 2  # type:ignore
+                    data_loader,
+                    data_loader.batch_size * 2,  # type:ignore
                 )
 
             (

--- a/vamb/encode.py
+++ b/vamb/encode.py
@@ -378,7 +378,8 @@ class VAE(_nn.Module):
 
         if epoch in batchsteps:
             data_loader = set_batchsize(
-                data_loader, data_loader.batch_size * 2  # type:ignore
+                data_loader,
+                data_loader.batch_size * 2,  # type:ignore
             )
 
         for depths_in, tnf_in, abundance_in, weights in data_loader:


### PR DESCRIPTION
This lets us use the same tool for both linting and formatting, simplifying things. Also, Ruff is faster, and installs with no dependencies.