### PR TITLE
Make TaxVamb taxonomy output format well-defined

### DIFF
--- a/.github/workflows/cli_vamb.yml
+++ b/.github/workflows/cli_vamb.yml
@@ -28,8 +28,8 @@ jobs:
         cache-dependency-path: '**/pyproject.toml'
     - name: Download fixtures
       run: |
-        wget https://www.dropbox.com/scl/fi/ivsqbao9we1lnyyyh43cc/ci_data.zip\?rlkey\=b9lcqxs63iv2409q5a7q1oh9z\&dl\=0 -O ci_data.zip
-        unzip ci_data.zip
+        wget https://www.dropbox.com/scl/fi/xzc0tro7oe6tfm3igygpj/ci_data.zip\?rlkey\=xuv6b5eoynfryp4fba1kfp5jm\&st\=9oz24ych\&dl\=0 -O ci_data.zip
+        unzip -o ci_data.zip
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -48,7 +48,7 @@ jobs:
         vamb bin taxvamb --outdir outdir_taxvamb_no_predict --no_predictor --fasta catalogue_mock.fna.gz --rpkm abundance_mock.npz --taxonomy taxonomy_mock.tsv -e 10 -q -t 10 -o C --minfasta 200000
         ls -la outdir_taxvamb_no_predict
         cat outdir_taxvamb_no_predict/log.txt
-        vamb bin taxvamb --outdir outdir_taxvamb_preds --fasta catalogue_mock.fna.gz --rpkm abundance_mock.npz  --no_predictor --taxonomy outdir_taxvamb/results_taxometer.csv --column_contigs contigs --column_taxonomy predictions --delimiter_taxonomy , -e 10 -q -t 10 -o C --minfasta 200000
+        vamb bin taxvamb --outdir outdir_taxvamb_preds --fasta catalogue_mock.fna.gz --rpkm abundance_mock.npz  --no_predictor --taxonomy outdir_taxvamb/results_taxometer.tsv -e 10 -q -t 10 -o C --minfasta 200000
         ls -la outdir_taxvamb_preds
         cat outdir_taxvamb_preds/log.txt
     - name: Run Taxometer
@@ -56,7 +56,7 @@ jobs:
         vamb taxometer --outdir outdir_taxometer --fasta catalogue_mock.fna.gz --rpkm abundance_mock.npz --taxonomy taxonomy_mock.tsv -pe 10 -pt 10
         ls -la outdir_taxometer
         cat outdir_taxometer/log.txt
-        vamb taxometer --outdir outdir_taxometer_pred --fasta catalogue_mock.fna.gz --rpkm abundance_mock.npz --taxonomy outdir_taxometer/results_taxometer.csv --column_contigs contigs --column_taxonomy predictions --delimiter_taxonomy , -pe 10 -pt 10
+        vamb taxometer --outdir outdir_taxometer_pred --fasta catalogue_mock.fna.gz --rpkm abundance_mock.npz --taxonomy outdir_taxometer/results_taxometer.tsv -pe 10 -pt 10
         ls -la outdir_taxometer_pred
         cat outdir_taxometer/log.txt
     - name: Run k-means reclustering

--- a/test/test_semisupervised_encode.py
+++ b/test/test_semisupervised_encode.py
@@ -31,10 +31,16 @@ class TestVAEVAE(unittest.TestCase):
         phylum = np.random.choice(self.phyla, 1)[0]
         clas = np.random.choice(self.classes[phylum], 1)[0]
         if np.random.random() <= 0.2:
-            return ";".join([self.domain])
+            return vamb.vambtools.ContigTaxonomy.from_semicolon_sep(
+                ";".join([self.domain])
+            )
         if 0.2 < np.random.random() <= 0.5:
-            return ";".join([self.domain, phylum])
-        return ";".join([self.domain, phylum, clas])
+            return vamb.vambtools.ContigTaxonomy.from_semicolon_sep(
+                ";".join([self.domain, phylum])
+            )
+        return vamb.vambtools.ContigTaxonomy.from_semicolon_sep(
+            ";".join([self.domain, phylum, clas])
+        )
 
     def make_random_annotations(self):
         return [self.make_random_annotation() for _ in range(self.N_contigs)]
@@ -47,7 +53,7 @@ class TestVAEVAE(unittest.TestCase):
             set(nodes).issubset(
                 set(
                     [
-                        "Domain",
+                        "root",
                         "d_Bacteria",
                         "f_1",
                         "f_2",
@@ -83,7 +89,7 @@ class TestVAEVAE(unittest.TestCase):
         annotations = self.make_random_annotations()
         nodes, ind_nodes, table_parent = vamb.taxvamb_encode.make_graph(annotations)
 
-        classes_order = np.array([a.split(";")[-1] for a in annotations])
+        classes_order = np.array([a.ranks[-1] for a in annotations])
         targets = np.array([ind_nodes[i] for i in classes_order])
 
         vae = vamb.taxvamb_encode.VAEVAEHLoss(

--- a/vamb/parsemarkers.py
+++ b/vamb/parsemarkers.py
@@ -278,7 +278,7 @@ def process_chunk(
 # only needs these two paths, and this marker name dict which we assume to be small.
 # The return type here is optimised for a small memory footprint.
 def work_per_process(
-    args: tuple[Path, Path, dict[MarkerName, MarkerID]]
+    args: tuple[Path, Path, dict[MarkerName, MarkerID]],
 ) -> list[tuple[ContigID, np.ndarray]]:
     (contig_path, hmmpath, name_to_id) = args
     with open(hmmpath, "rb") as file:

--- a/vamb/reclustering.py
+++ b/vamb/reclustering.py
@@ -19,7 +19,9 @@ from loguru import logger
 import vamb
 
 
-def get_best_bin(results_dict, contig_to_marker, namelist, contig_dict, minfasta):
+def get_best_bin(
+    results_dict, contignames, contig_to_marker, namelist, contig_dict, minfasta
+):
     # There is room for improving the loop below to avoid repeated computation
     # but it runs very fast in any case
     for max_contamination in [0.1, 0.2, 0.3, 0.4, 0.5, 1]:


### PR DESCRIPTION
Previously, the taxonomy format input to TaxVamb was poorly defined, and did not correspond to the format output by Taxometer.
This had a couple of bad consequences:
1. It made it more difficult to specify what format the user should format the supplied taxonomy with
2. The taxonomy format was too tightly coupled to the particular program that generated it (an artifact from when we just used mmseqs2, I believe)
3. It required three extra command-line params just to specify columns and separator for the taxonomy
4. It required the use of general-purpose parsers in Pandas, which is fragile.

Now, with these changes, we have:
* Three command-line arguments removed
* __main__.py no longer depends on Pandas, it is also thoroughly statically analyzable
* More robust parsing with better error messages.