### PR TITLE
Do not ingore errors caught by Loguru

### DIFF
--- a/vamb/__main__.py
+++ b/vamb/__main__.py
@@ -1383,7 +1383,7 @@ class BasicArguments(object):
     def run_inner(self):
         raise NotImplementedError
 
-    @logger.catch()
+    @logger.catch(reraise=True)
     def run(self):
         torch.set_num_threads(self.vamb_options.n_threads)
         try_make_dir(self.vamb_options.out_dir)


### PR DESCRIPTION
In 62baa358, I added `@logger.catch` to `run` in order for Loguru to catch and log any errors emitted by Vamb.
However, I did not notice that this will cause any caught errors to exit Vamb with a return code of zero.
This broke CI and undoubtedly will break snakemake pipelines relying on Vamb.