### PR TITLE
Silence NumPy warning about float subnormals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,10 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
-lint.ignore = ["E722", "E501"]
+lint.ignore = [
+    "E722", # Use bare except.
+    "E402", # import not at top - needed for the hack in __init__.py
+]
 
 # pyproject.toml
 [tool.pytest.ini_options]

--- a/vamb/__init__.py
+++ b/vamb/__init__.py
@@ -2,6 +2,16 @@
 Documentation: https://github.com/RasmussenLab/vamb/
 """
 
+# TODO: Pyhmmer is compiled with -funsafe-math-optimizations, which toggles some
+# flag in the CPU controlling float subnormal behaviour.
+# This causes a warning in NumPy.
+# This is not an issue in Vamb (I think), so we silence the warning here as a
+# temporary fix.
+# See https://github.com/althonos/pyhmmer/issues/71
+import warnings
+
+warnings.filterwarnings("ignore", category=UserWarning, module="numpy")
+
 from . import vambtools
 from . import parsebam
 from . import parsecontigs

--- a/vamb/__main__.py
+++ b/vamb/__main__.py
@@ -1923,7 +1923,7 @@ def add_clustering_arguments(subparser):
         dest="max_clusters",
         metavar="",
         type=int,
-        default=None, # meaning: do not stop
+        default=None,  # meaning: do not stop
         help=argparse.SUPPRESS,
     )
 

--- a/vamb/encode.py
+++ b/vamb/encode.py
@@ -81,7 +81,9 @@ def make_dataloader(
         raise ValueError(f"Batch size must be minimum 1, not {batchsize}")
 
     if len(abundance) != len(tnf) or len(tnf) != len(lengths):
-        raise ValueError("Lengths of abundance, TNF and lengths arrays must be the same")
+        raise ValueError(
+            "Lengths of abundance, TNF and lengths arrays must be the same"
+        )
 
     if not (abundance.dtype == tnf.dtype == _np.float32):
         raise ValueError("TNF and abundance must be Numpy arrays of dtype float32")

--- a/vamb/vambtools.py
+++ b/vamb/vambtools.py
@@ -55,7 +55,7 @@ class BinSplitter:
                 self.splitter = None
             else:
                 self.splitter = binsplitter
-        
+
         self.is_initialized = False
 
     @classmethod


### PR DESCRIPTION
The dependency pyhmmer is compiled with -funsafe-math-optimizations. Loading a lib compiled with that flag will set some flags in the CPU for the whole process, which changes float subnormal behaviour.
This is detected when loading NumPy, raising a warning. I believe this is not an issue for Vamb, so I just silence the warning for now. I'm not too happy with this "solution".