### PR TITLE
Set default taxometer batch steps to no steps

### DIFF
--- a/vamb/__main__.py
+++ b/vamb/__main__.py
@@ -1863,7 +1863,7 @@ def add_predictor_arguments(subparser):
         metavar="",
         type=int,
         nargs="*",
-        default=[25, 75, 150, 225],
+        default=[],
         help=argparse.SUPPRESS,
     )
     pred_trainos.add_argument(


### PR DESCRIPTION
The previous defaults were conflicting, since the default number of epochs was smaller than the last steps.
Previous runs have indicated that no steps is a good option, though I believe we have never done any optimization on this.

Closes #358 