### PR TITLE
Fix cuda utilization and CLI for Taxometer

### DIFF
--- a/.github/workflows/cli_vamb.yml
+++ b/.github/workflows/cli_vamb.yml
@@ -42,7 +42,7 @@ jobs:
         cat outdir_vamb/log.txt
     - name: Run TaxVAMB
       run: |
-        vamb bin taxvamb --outdir outdir_taxvamb --fasta catalogue_mock.fna.gz --abundance abundance_mock.npz --taxonomy taxonomy_mock.tsv -pe 10 -pt 10 -e 10 -q -pq -t 10 -o C --minfasta 200000
+        vamb bin taxvamb --outdir outdir_taxvamb --fasta catalogue_mock.fna.gz --abundance abundance_mock.npz --taxonomy taxonomy_mock.tsv -pe 10 -pt 10 -e 10 -q -t 10 -o C --minfasta 200000
         ls -la outdir_taxvamb
         cat outdir_taxvamb/log.txt
         vamb bin taxvamb --outdir outdir_taxvamb_no_predict --no_predictor --fasta catalogue_mock.fna.gz --abundance abundance_mock.npz --taxonomy taxonomy_mock.tsv -e 10 -q -t 10 -o C --minfasta 200000
@@ -53,10 +53,10 @@ jobs:
         cat outdir_taxvamb_preds/log.txt
     - name: Run Taxometer
       run: |
-        vamb taxometer --outdir outdir_taxometer --fasta catalogue_mock.fna.gz --abundance abundance_mock.npz --taxonomy taxonomy_mock.tsv -pe 10 -pq -pt 10
+        vamb taxometer --outdir outdir_taxometer --fasta catalogue_mock.fna.gz --abundance abundance_mock.npz --taxonomy taxonomy_mock.tsv -pe 10 -pt 10
         ls -la outdir_taxometer
         cat outdir_taxometer/log.txt
-        vamb taxometer --outdir outdir_taxometer_pred --fasta catalogue_mock.fna.gz --abundance abundance_mock.npz --taxonomy outdir_taxometer/results_taxometer.tsv -pe 10 -pq -pt 10
+        vamb taxometer --outdir outdir_taxometer_pred --fasta catalogue_mock.fna.gz --abundance abundance_mock.npz --taxonomy outdir_taxometer/results_taxometer.tsv -pe 10 -pt 10
         ls -la outdir_taxometer_pred
         cat outdir_taxometer/log.txt
     - name: Run k-means reclustering

--- a/vamb/__main__.py
+++ b/vamb/__main__.py
@@ -240,7 +240,7 @@ class BasicTrainingOptions:
         return cls(
             typeasserted(args.pred_nepochs, int),
             typeasserted(args.pred_batchsize, int),
-            typeasserted(args.pred_batchsteps, list),
+            [],
         )
 
     def __init__(
@@ -1855,15 +1855,6 @@ def add_predictor_arguments(subparser):
         metavar="",
         type=int,
         default=1024,
-        help=argparse.SUPPRESS,
-    )
-    pred_trainos.add_argument(
-        "-pq",
-        dest="pred_batchsteps",
-        metavar="",
-        type=int,
-        nargs="*",
-        default=[],
         help=argparse.SUPPRESS,
     )
     pred_trainos.add_argument(

--- a/vamb/taxvamb_encode.py
+++ b/vamb/taxvamb_encode.py
@@ -824,9 +824,6 @@ class VAMB2Label(_nn.Module):
         self.tree = _hloss.Hierarchy(table_parent)
         self.n_tree_nodes = nlabels
 
-        if cuda:
-            self.cuda()
-
         self.nodes = nodes
         self.table_parent = table_parent
         self.hierloss = init_hier_loss(hier_loss, self.tree)
@@ -854,6 +851,9 @@ class VAMB2Label(_nn.Module):
         # Activation functions
         self.relu = _nn.LeakyReLU()
         self.dropoutlayer = _nn.Dropout(p=self.dropout)
+
+        if cuda:
+            self.cuda()
 
     def _predict(self, tensor: Tensor) -> tuple[Tensor, Tensor]:
         tensors: list[_torch.Tensor] = list()


### PR DESCRIPTION
Two changes:
- fixed a bug where not all the Taxometer layers are transfered to GPU
- removed the batch steps for all the taxonomy models (Taxometer and TaxVAMB) with corresponding test changes.

Solves https://github.com/RasmussenLab/vamb/issues/360 and https://github.com/RasmussenLab/vamb/issues/358