### PR TITLE
Clear invalidated medoid cache on packing

### DIFF
--- a/vamb/cluster.py
+++ b/vamb/cluster.py
@@ -325,6 +325,8 @@ class ClusterGenerator:
         self.lengths = self.lengths[self.kept_mask]
         self.kept_mask.resize_(len(self.matrix))
         self.kept_mask[:] = 1
+        # The medoid cache is invalidated when the indices shifts
+        self.medoid_cache.clear()
 
     def pack_order(self):
         "Remove all used points from self.order"


### PR DESCRIPTION
Packing the indices of a ClusterGenerator shifts the meaning of the integers in its cache, invalidating it.
I suppose they could be updated in the cache, but that'd be a complex piece of code a clustering implementation which is already too complex for its own good. Instead, clear the cache when packing.

This should happen a neglible amount of times compared to how often we already clear the cache.