### PR TITLE
Use the correct binsplitter in TaxVamb

### DIFF
--- a/vamb/__main__.py
+++ b/vamb/__main__.py
@@ -1509,7 +1509,7 @@ def run_vaevae(opt: BinTaxVambOptions):
         vamb_options=opt.common.general,
         comp_options=opt.common.comp,
         abundance_options=opt.common.abundance,
-        binsplitter=vamb.vambtools.BinSplitter.inert_splitter(),
+        binsplitter=opt.common.output.binsplitter,
     )
     abundance, tnfs, lengths, contignames = (
         abundance.matrix,


### PR DESCRIPTION
Previously, TaxVamb incorrectly used the inert splitter instead of the one specified on command-line, when loading its composition. Since the binsplitter is properly initialized in `calc_tnf`, such that it will not attempt to binsplit on 'C' if this separator is not present, the use of an inert splitter skipped this initialization.
This caused a bug where the lack of a separator was not detected until the data was clustered, far too late.