### PR TITLE
Fix: Don't re-sample sample medoid candidate repeatedly

### DIFF
--- a/vamb/cluster.py
+++ b/vamb/cluster.py
@@ -422,7 +422,7 @@ class ClusterGenerator:
             sampled_medoid = candidates[i]
             tried.add(sampled_medoid)
             sample_cluster, sample_distances, sample_density = self.sample_medoid(
-                medoid
+                sampled_medoid
             )
 
             # If the mean distance of inner points of the sample is lower,


### PR DESCRIPTION
Commit d35788c introduced a bug, where sample_medoid was being called repeatedly on the currently best medoid, instead of the different medoid candidates. This effectively disables medoid wandering, therefore degrading clustering. Fix this.