### PR TITLE
Only drop_last with enough elements in data loaders

### DIFF
--- a/vamb/__main__.py
+++ b/vamb/__main__.py
@@ -1056,7 +1056,8 @@ def trainvae(
     begintime = time.time()
     logger.info("Creating and training VAE")
 
-    nsamples = data_loader.dataset.tensors[0].shape[1]  # type:ignore
+    n_obs = data_loader.dataset.tensors[0].shape[0]  # type: ignore
+    nsamples = data_loader.dataset.tensors[0].shape[1]  # type: ignore
     vae = vamb.encode.VAE(
         nsamples,
         nhiddens=vae_options.nhiddens,
@@ -1072,7 +1073,9 @@ def trainvae(
     modelpath = vamb_options.out_dir.joinpath("model.pt")
     vae.trainmodel(
         vamb.encode.set_batchsize(
-            data_loader, vae_options.basic_options.starting_batch_size
+            data_loader,
+            vae_options.basic_options.starting_batch_size,
+            n_obs,
         ),
         nepochs=vae_options.basic_options.num_epochs,
         batchsteps=vae_options.basic_options.batch_steps,
@@ -1115,8 +1118,11 @@ def trainaae(
 
     logger.info("\tCreated AAE")
     modelpath = os.path.join(vamb_options.out_dir, "aae_model.pt")
+    n_obs = data_loader.dataset.tensors[0].shape[0]  # type: ignore
     aae.trainmodel(
-        vamb.encode.set_batchsize(data_loader, aae_options.basic.starting_batch_size),
+        vamb.encode.set_batchsize(
+            data_loader, aae_options.basic.starting_batch_size, n_obs
+        ),
         aae_options.basic.num_epochs,
         aae_options.basic.batch_steps,
         aae_options.temp,

--- a/vamb/aamb_encode.py
+++ b/vamb/aamb_encode.py
@@ -262,6 +262,7 @@ class AAE(nn.Module):
                 data_loader = set_batchsize(
                     data_loader,
                     data_loader.batch_size * 2,  # type:ignore
+                    data_loader.dataset.tensors[0].shape[0],
                 )
 
             (
@@ -446,8 +447,10 @@ class AAE(nn.Module):
             l_latents array"""
         self.eval()
 
-        new_data_loader = set_batchsize(data_loader, 256, encode=True)
         depths_array, _, _, _ = data_loader.dataset.tensors
+        new_data_loader = set_batchsize(
+            data_loader, 256, len(depths_array), encode=True
+        )
 
         length = len(depths_array)
         latent = np.empty((length, self.ld), dtype=np.float32)

--- a/vamb/encode.py
+++ b/vamb/encode.py
@@ -31,7 +31,7 @@ import torch as _torch
 
 
 def set_batchsize(
-    data_loader: _DataLoader, batch_size: int, encode=False
+    data_loader: _DataLoader, batch_size: int, n_obs: int, encode=False
 ) -> _DataLoader:
     """Effectively copy the data loader, but with a different batch size.
 
@@ -43,7 +43,7 @@ def set_batchsize(
         dataset=data_loader.dataset,
         batch_size=batch_size,
         shuffle=not encode,
-        drop_last=False,
+        drop_last=not encode and (n_obs > batch_size),
         num_workers=1 if encode else data_loader.num_workers,
         pin_memory=data_loader.pin_memory,
     )
@@ -136,7 +136,7 @@ def make_dataloader(
     dataloader = _DataLoader(
         dataset=dataset,
         batch_size=batchsize,
-        drop_last=False,
+        drop_last=(len(depthstensor) > batchsize),
         shuffle=True,
         num_workers=n_workers,
         pin_memory=cuda,
@@ -362,10 +362,11 @@ class VAE(_nn.Module):
         optimizer,
         batchsteps: list[int],
     ) -> _DataLoader[tuple[Tensor, Tensor, Tensor]]:
-        if len(data_loader.dataset.tensors[0]) < 2:
+        n_seq = len(data_loader.dataset.tensors[0])
+        if n_seq:
             raise ValueError(
                 "Cannot train on a dataset with fewer than 2 sequences, but got "
-                f"{len(data_loader.dataset.tensors[0])} sequences. "
+                f"{n_seq} sequences. "
                 "If you are trying to fit a DL model to this few sequences, "
                 "something probably went wrong in your pipeline."
             )
@@ -382,6 +383,7 @@ class VAE(_nn.Module):
             data_loader = set_batchsize(
                 data_loader,
                 data_loader.batch_size * 2,  # type:ignore
+                n_seq,
             )
 
         for depths_in, tnf_in, abundance_in, weights in data_loader:
@@ -446,11 +448,11 @@ class VAE(_nn.Module):
 
         self.eval()
 
+        depths_array, _, _, _ = data_loader.dataset.tensors
         new_data_loader = set_batchsize(
-            data_loader, data_loader.batch_size, encode=True
+            data_loader, data_loader.batch_size, len(depths_array), encode=True
         )
 
-        depths_array, _, _, _ = data_loader.dataset.tensors
         length = len(depths_array)
 
         # We make a Numpy array instead of a Torch array because, if we create

--- a/vamb/encode.py
+++ b/vamb/encode.py
@@ -363,7 +363,7 @@ class VAE(_nn.Module):
         batchsteps: list[int],
     ) -> _DataLoader[tuple[Tensor, Tensor, Tensor]]:
         n_seq = len(data_loader.dataset.tensors[0])
-        if n_seq:
+        if n_seq < 2:
             raise ValueError(
                 "Cannot train on a dataset with fewer than 2 sequences, but got "
                 f"{n_seq} sequences. "


### PR DESCRIPTION
Some models in Vamb used dataloaders with `drop_last=True`. One rationale for this is that the last mini batch, having fewer elements, is likely to give inflated gradients, which will disrupt training.
However, since Vamb uses rather large batch sizes, this can easily result in a situation where the total number of observations is smaller than the batch size, which will result in an error, as no samples can be loaded from the dataset.

Here, we only set `drop_last` if there are more observations than one mini batch size.

Close #424 