### PR TITLE
Allow taxonomy to contain filtered contigs

### DIFF
--- a/vamb/taxonomy.py
+++ b/vamb/taxonomy.py
@@ -81,19 +81,26 @@ class Taxonomy:
         contig_taxonomies: list[Optional[ContigTaxonomy]] = [None] * len(
             metadata.identifiers
         )
+        n_found = 0
         for contigname, taxonomy in observed_taxonomies:
             index = index_of_contigname.get(contigname)
             if index is None:
-                raise ValueError(
-                    f'When parsing taxonomy, found contigname "{contigname}", '
-                    "but no sequence of that name is in the FASTA file"
-                )
+                continue
+            n_found += 1
             existing = contig_taxonomies[index]
             if existing is not None:
                 raise ValueError(
                     f'Duplicate contigname when parsing taxonomy: "{contigname}"'
                 )
             contig_taxonomies[index] = taxonomy
+
+        if n_found != metadata.nseqs:
+            raise ValueError(
+                f"In taxonomy file, expected {metadata.nseqs} contigs that are "
+                f"also present in the filtered FASTA file, but found {n_found}. "
+                "Note that this might occur because some contigs in the taxonomy "
+                "file falls under the minimum length threshold."
+            )
         return cls(contig_taxonomies, metadata.refhash, is_canonical)
 
     def __init__(


### PR DESCRIPTION
When parsing a Taxonomy object, each seq in the input file needs to be matched with the existing seq in the CompositionMetaData. However, seqs may be filtered from the latter, if they fall below the minimum length. So, when we encounter a seq in the taxonomy file not present in the composition, how do we know if it's invalid, or merely filtered?

We have the following (bad) options:
1. Use the refhashing mechanism, which requires the sequences are in the same order as in the composition. This is an extra constraint on the input file, which is a kind of breaking change (but unlikely to actually break anything)
2. Have a length column in the taxonomy file. This is clearly a breaking chnage, since input files will no longer work.
3. Skip any sequence not present in the composition, but then check that the taxonomy contained all the sequences in the composition. Thus, do less validation than would be optimal, but no breakage

This commit goes with option 3.

Closes #438 