### PR TITLE
Bugfix: Parse empty taxonomy as empty list

### DIFF
--- a/vamb/taxonomy.py
+++ b/vamb/taxonomy.py
@@ -1,6 +1,7 @@
 from typing import Optional, IO
 from pathlib import Path
 from vamb.parsecontigs import CompositionMetaData
+from vamb.vambtools import strip_string_newline
 import numpy as np
 from typing import Union
 
@@ -29,7 +30,10 @@ class ContigTaxonomy:
 
     @classmethod
     def from_semicolon_sep(cls, s: str, is_canonical: bool = False):
-        return cls(s.split(";"), is_canonical)
+        if len(s) == 0:
+            return cls([], is_canonical)
+        else:
+            return cls(s.split(";"), is_canonical)
 
     @property
     def genus(self) -> Optional[str]:
@@ -129,6 +133,7 @@ class Taxonomy:
                 )
             # Minus two because we already read header, and because Python is zero-indexed
             for lineno_minus_two, line in enumerate(file):
+                line = strip_string_newline(line)
                 fields = line.split("\t")
                 if len(fields) != 2:
                     raise ValueError(

--- a/vamb/vambtools.py
+++ b/vamb/vambtools.py
@@ -434,6 +434,16 @@ def strip_newline(s: bytes) -> bytes:
         return s
 
 
+def strip_string_newline(s: str) -> str:
+    if len(s) > 0 and s[-1] == "\n":
+        if len(s) > 1 and s[-2] == "\r":
+            return s[:-2]
+        else:
+            return s[:-1]
+    else:
+        return s
+
+
 def byte_iterfasta(
     filehandle: Iterable[bytes], filename: Optional[str]
 ) -> Iterator[FastaEntry]:


### PR DESCRIPTION
Previously, it got parsed as `[""]`.