### PR TITLE
Improve printing of VAEVAE loss in log

### DIFF
--- a/vamb/semisupervised_encode.py
+++ b/vamb/semisupervised_encode.py
@@ -1000,8 +1000,9 @@ class VAEVAE(object):
         metrics_dict["correct_labels_joint"] /= data_loader.batch_size
         metrics_dict["correct_labels_labels"] /= data_loader.batch_size
         logger.info(
-            ", ".join(
-                [k + f" {v / len(data_loader):.6f}" for k, v in metrics_dict.items()]
+            f"\t\tEpoch: {epoch}  "
+            + "  ".join(
+                [k + f": {v / len(data_loader):.5e}" for k, v in metrics_dict.items()]
             )
         )
 


### PR DESCRIPTION
* Print in scientific notation, to allow small losses to not round to zero
* Print the epoch number so people know how far the network has come
* Indent the loss lines similar to the VAE loss's log lines