### PR TITLE
Fix: In TaxVamb, use Taxometer CLI options for Taxometer

### DIFF
--- a/doc/how_to_run.md
+++ b/doc/how_to_run.md
@@ -81,8 +81,8 @@ For testing purposes, e.g. when running on the test data, it may be useful to re
 This will cause Vamb's models to be severely underfitted and perform terribly, so doing it is only recommended for testing.
 
 * For Vamb: Add flags `-e 5 -q 2 3`
-* For TaxVamb: Add flags `-e 5 -q 2 3 -pe 5 -pq 2 3`
-* For Taxometer: Add flags `-pe 5 -pq 2 3`
+* For TaxVamb: Add flags `-e 5 -q 2 3 -pe 5`
+* For Taxometer: Add flags `-pe 5`
 
 ## Explanation of command-line options
 Each program in Vamb only has a subset of the following options.

--- a/vamb/__main__.py
+++ b/vamb/__main__.py
@@ -769,7 +769,7 @@ class BinTaxVambOptions:
                     common.comp,
                     common.abundance,
                     taxonomy,
-                    basic,
+                    BasicTrainingOptions.from_args_taxometer(args),
                     typeasserted(args.pred_softmax_threshold, float),
                     args.ploss,
                 )
@@ -2048,15 +2048,6 @@ def add_predictor_arguments(subparser: argparse.ArgumentParser):
         metavar="",
         type=int,
         default=1024,
-        help=argparse.SUPPRESS,
-    )
-    pred_trainos.add_argument(
-        "-pq",
-        dest="pred_batchsteps",
-        metavar="",
-        type=int,
-        nargs="*",
-        default=[25, 75],
         help=argparse.SUPPRESS,
     )
     pred_trainos.add_argument(


### PR DESCRIPTION
Previously, the VAEVAE's batch size and epochs were used. Also, delete the -pq option, which was never used, even when set.