### PR TITLE
Refactor cluster printing

### DIFF
--- a/vamb/vambtools.py
+++ b/vamb/vambtools.py
@@ -9,7 +9,7 @@ from vambcore import kmercounts, overwrite_matrix
 import collections as _collections
 from itertools import zip_longest
 from hashlib import md5 as _md5
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Collection
 from typing import Optional, IO, Union
 from pathlib import Path
 from loguru import logger
@@ -634,7 +634,7 @@ def create_dir_if_not_existing(path: Path) -> None:
 
 def write_bins(
     directory: Path,
-    bins: dict[str, set[str]],
+    bins: Collection[tuple[str, Iterable[str]]],
     fastaio: Iterable[bytes],
     maxbins: Optional[int] = 1000,
 ):
@@ -657,8 +657,9 @@ def write_bins(
     create_dir_if_not_existing(directory)
 
     keep: set[str] = set()
-    for i in bins.values():
-        keep.update(i)
+    for _, contigs in bins:
+        for contig in contigs:
+            keep.add(contig)
 
     bytes_by_id: dict[str, bytes] = dict()
     for entry in byte_iterfasta(fastaio, None):
@@ -668,7 +669,7 @@ def write_bins(
             )
 
     # Now actually print all the contigs to files
-    for binname, contigs in bins.items():
+    for binname, contigs in bins:
         for contig in contigs:
             byts = bytes_by_id.get(contig)
             if byts is None:


### PR DESCRIPTION
This PR picks up some of the remaining work from Elek's recent refactoring of cluster printing. It simplifies the logical flow of contig printing by reducing the number of functions.

The logic is more clear about when printing happens: It now separates the cluster writing into two functions: One clusters and writes the associated files while clustering. Another function, used e.g. when reclustering, merely writes the files.

This commit also:
* Fixes a bunch of type errors, making the code pass typecheck
* More thoroughly encodes the state into the type system: i.e. if arguments A and B are needed together, or not at all, they are condensed in a single variable of type Option[tuple[A, B]].